### PR TITLE
BST-14 Fix or suppress rubocop violations in spec/**/*.rb

### DIFF
--- a/ruby/lib/tree.rb
+++ b/ruby/lib/tree.rb
@@ -39,6 +39,10 @@ class Tree
     root.nil? ? true : false
   end
 
+  def set_root_to_nil
+    @root = nil
+  end
+
   def insert node
     @root.insert node
     @size += 1

--- a/ruby/spec/binary_search_tree_spec.rb
+++ b/ruby/spec/binary_search_tree_spec.rb
@@ -485,6 +485,8 @@ describe Foo do
   end
 
   describe 'method overriding' do
+    # TODO: Find a lint-compliant way to spec the `include`
+    # rubocop:disable Lint/ConstantDefinitionInBlock
     class Bar
       require 'securerandom'
       include BinarySearchTree
@@ -495,6 +497,7 @@ describe Foo do
         @uuid = SecureRandom.uuid
       end
     end
+    # rubocop:enable Lint/ConstantDefinitionInBlock
 
     it 'fails if comparison operator is not overriden' do
       bar = Bar.new 9

--- a/ruby/spec/node_spec.rb
+++ b/ruby/spec/node_spec.rb
@@ -793,8 +793,7 @@ describe Node do
         end
       end
 
-      describe 'left and right children, alternately aperiodically' do
-      end
+      describe 'left and right children, alternately aperiodically'
     end
   end
 end

--- a/ruby/spec/tree_spec.rb
+++ b/ruby/spec/tree_spec.rb
@@ -51,12 +51,6 @@ RSpec.describe Tree do
     end
 
     it 'returns true when root node is not present' do
-      class Tree
-        def set_root_to_nil
-          # root is attr_reader
-          @root = nil
-        end
-      end
       tree = Tree.new
       tree.set_root_to_nil
       expect(tree.empty?).to be true


### PR DESCRIPTION
These changes are relatively minor, and may or may not warrant deeper
investigation in the future.

Of the suppressions which won't just "go away" it's worth learning
how better to test modules which get included. There has to be
a best practice other than defining a temporary class.