### PR TITLE
BST-23 stern-brocot - initial implementation

### DIFF
--- a/ruby/.reek.yml
+++ b/ruby/.reek.yml
@@ -57,4 +57,5 @@ exclude_paths:
   - lib/gcd.rb
   - lib/binary_search_tree.rb
   - lib/avl_node.rb
+  - lib/stern_brocot.rb
   - vendor/

--- a/ruby/lib/stern_brocot.rb
+++ b/ruby/lib/stern_brocot.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+class SternBrocot
+  MAX = 2**(1.size * 8 - 2) - 1
+  TOL = 0.001
+
+  # rubocop:disable  Metrics/AbcSize
+  # rubocop:disable Metrics/MethodLength
+  def self.rationalize(number)
+    # rubocop:disable Lint/FloatComparison
+    return [0, 1] if number.to_f == 0.0
+
+    # rubocop:enable Lint/FloatComparison
+
+    q = number
+
+    a = 0
+    b = 1
+    c = 1
+    d = 0
+
+    _l = a / b
+    _h = d.zero? ? MAX : c / d
+    mn = a + b
+    md = c + d
+    m = mn / md.to_f
+
+    iteration = 1 # ejection handle
+
+    loop do
+      return [mn.to_i, md.to_i] if m == q
+
+      if m < q
+        a = mn
+        b = md
+        # l = m
+      else # m > q
+        c = mn
+        d = md
+        # h = m
+      end
+
+      mn = a + b
+      md = c + d
+      m = mn / md.to_f
+
+      # return [mn.to_i, md.to_i] if m == q
+      return [mn.to_i, md.to_i] if (m - q).abs < TOL
+
+      iteration += 1
+      # puts md.to_i if md.to_i.modulo(10).zero?
+      break if iteration > 15
+    end
+
+    # also, return if past a certain threshold in precision
+    # return [a+b, c+d] if Math.abs(q - number) < 0.0005
+    [mn.to_i, md.to_i]
+
+    # rubocop:disable Layout/LineLength
+    # Initialize two values L and H to 0/1 and 1/0, respectively.
+    #  Until q is found, repeat the following steps:
+    #  Let L = a/b and H = c/d; compute the mediant M = (a + c)/(b + d).
+    #  If M is less than q, then q is in the open interval (M,H); replace L by M and continue.
+    #  If M is greater than q, then q is in the open interval (L,M); replace H by M and continue.
+    #  In the remaining case, q = M; terminate the search algorithm.
+    # rubocop:enable Layout/LineLength
+  end
+  # rubocop:enable Metrics/MethodLength
+  # rubocop:enable  Metrics/AbcSize
+end

--- a/ruby/spec/stern_brocot_spec.rb
+++ b/ruby/spec/stern_brocot_spec.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require_relative '../lib/stern_brocot'
+
+RSpec.describe SternBrocot do
+  it 'instantiates' do
+    expect(SternBrocot.new).not_to be nil
+  end
+
+  describe '.rationalize' do
+    context 'integers >= 0' do
+      example '0 yields 0/1' do
+        actual = SternBrocot.rationalize 0
+        expect(actual).to eq [0, 1]
+      end
+
+      example '1 yields 1/1' do
+        actual = SternBrocot.rationalize 1
+        expect(actual).to eq [1, 1]
+      end
+
+      example '2 yields 2/1' do
+        actual = SternBrocot.rationalize 2
+        expect(actual).to eq [2, 1]
+      end
+
+      xexample '1246 yields 1246/1' do
+        actual = SternBrocot.rationalize 1246
+        expect(actual).to eq [1246, 1]
+      end
+    end
+
+    context 'rational numbers <= 1.0' do
+      example '0.0 yields 0/1' do
+        actual = SternBrocot.rationalize 0.0
+        expect(actual).to eq [0, 1]
+      end
+
+      example '1.0 yields 1/1' do
+        actual = SternBrocot.rationalize 1.0
+        expect(actual).to eq [1, 1]
+      end
+
+      example '0.5 yields 1/2' do
+        actual = SternBrocot.rationalize 0.5
+        expect(actual).to eq [1, 2]
+      end
+
+      example '0.1 yields 1/10' do
+        actual = SternBrocot.rationalize 0.1
+        expect(actual).to eq [1, 10]
+      end
+
+      xexample '0.15 yields 15/100' do
+        actual = SternBrocot.rationalize 0.15
+        expect(actual).to eq [15, 100]
+      end
+
+      xexample '0.3 yields 3/10' do
+        actual = SternBrocot.rationalize 0.3
+        expect(actual).to eq [3, 10]
+      end
+
+      xexample '0.333 yields 333/1000' do
+        actual = SternBrocot.rationalize 0.333
+        expect(actual).to eq [333, 1000]
+      end
+    end
+
+    context 'rational numbers > 1.0' do
+      xexample '1.1 yields 11/10' do
+        actual = SternBrocot.rationalize 1.1
+        expect(actual).to eq [11, 10]
+      end
+
+      example '3.1'
+      example '5.2'
+      example '9.9'
+      example '123.123'
+    end
+
+    #     context 'irrational numbers' do
+    #       context 'pi' do
+    #         example 'to 1 decimal place'
+    #         example 'to 2 decimal places'
+    #         example 'to 3 decimal places'
+    #         example 'to 4 decimal places'
+    #         example 'to 5 decimal places'
+    #       end
+    #
+    #       context 'e' do
+    #         example 'to 1 decimal place'
+    #         example 'to 2 decimal places'
+    #         example 'to 3 decimal places'
+    #         example 'to 4 decimal places'
+    #         example 'to 5 decimal places'
+    #       end
+    #     end
+  end
+end


### PR DESCRIPTION
integers >= 0 work

This turned out to be a bit easier than I
thought it would be, for at least the
simple (trivial) iterative technique. Hopefully
I got it right and it will work for rational
numbers, because that's the point.

rational numbers <= 1

This is partially working, committed to keep
track of where the implementation needs to be
fixed. Whatever the problem is, it's almost
surely very simple.