### PR TITLE
BST-24 initial implementation of AVL tree

### DIFF
--- a/doc/bst.tex
+++ b/doc/bst.tex
@@ -12,7 +12,8 @@
 \maketitle
 
 \abstract{A few notes on binary search trees and their implementations
-in various programming languages.}
+in various programming languages. While theory is not neglected, implementation
+details are preeminent.}
 
 \tableofcontents
 
@@ -480,6 +481,189 @@ including class.
 The usual caveats about instance variables referenced in modules applies,
 particularly that the including class must define the key for the tree.
 
+\section{AVL tree}
+
+AVL trees are a type of binary search tree which maintains height balance
+on insert operations by \textit{retracing} the insertion path of the node,
+and performing \textit{node rotation} at every node in the retrace path
+which became unbalanced on the insert. AVL trees are not that technically
+difficult to implement, but there are a few tedious details requiring
+precise attention. Some factors to consider:
+
+\begin{enumerate}
+  \item Where the retracing is implemented depends on how the tree and
+    node data structures are implemented. Because the root node may change
+    as a result of rotation, the Tree data structure will have to have a way
+    of ensuring the current root is valid.
+  \item Retracing can be done from the tree, or as part of the node capability.
+  \item Rotations ultimately decompose into two cases. The first case is moving
+    a left (right) child into its parent's position, the other case is swapping a right (left)
+    child for its parent, where both cases require ensuring all relevant pointers
+    are updated accordingly.
+\end{enumerate}
+
+We'll work our way backwards through the above list, starting with a detailed
+discussion of rotation, which is the fun part everyone wants to do anyway.
+
+\subsection{Rotation}
+
+There are plenty of references, web sites, Youtube videos and whatnot
+where AVL rotation is explained in detail. None of them are wrong, but
+most go into extraneous detail far too quickly, presenting situations
+which will be hard to visualize during implementation, and possibly
+difficult to construct for testing. It turns out, as claimed above,
+that rotations are fundamentally about parent/child repositioning
+while ensuring all the relevant pointers are updated accordingly.
+
+Ironically, it's easier to motivate rotations using 3 nodes instead
+of two nodes. The idea is putting a binary search tree back into
+balance, and by definition, and AVL tree of size 2 is balanced.
+So we need 3 nodes to see what the problem is, and how to solve it.
+
+Three nodes results in 5 different binary search trees. We may discard
+the balanced tree from our conversation immediately, leaving the other
+4 trees out of balance, by definition. Of these 4 trees, we can use
+symmetry to dispose of all the remaining trees with nodes right (or left)
+leaving two cases to consider. While both cases are ``skew'' trees
+(all the nodes have one and only one child), it's useful to note
+that Case 1 has left children only, and Case 2 has a left child then
+a right child. (Conversely, right children only, and right then
+left child). We'll call Case 1 a \textit{left chain} and Case 2 a
+\textit{left knee}.
+
+FIGURES HERE.
+
+\subsubsection{Left chain}
+
+Suppose in the left chain we have a root keyed 17, and child left
+7, then 2. For balance, we want the new root to be 7, with right 17
+and left 2.
+
+It's helpful here to distinguish between the root of the tree, and a
+some local \textit{rotation root}. In this base case, the tree root
+and the rotation root are the same node. In the general case, the
+tree root and rotation root will be different, and we're going to
+lean on our rapidly developing data structures intuition to keep the
+context straight.
+
+Continuing, the node keyed 17 is chosen as the \textit{rotation root}.
+The node 7 we'll call the \textit{pivot}. Implementing this rotation
+to balance the tree requires:
+
+\begin{enumerate}
+  \item Save the parent pointer of the rotation root (nil in this case).
+  \item Move the node 17 to 7's right child, updating 17's parent pointer.
+  \item Set 7's parent pointer to the saved value.
+\end{enumerate}
+
+\subsubsection{Left knee}
+
+In the left knee, let's have our root 17, with left 7, and 7's right
+child 11. In this case, we want 11 to be the root, with 7 as left
+child and 17 as right child. Simply moving 7 into the tree root
+position won't work, it will violate the binary search tree definition.
+And besides, we can't put 17 on 7's right, 11 is already there.
+Instead, what we do first is rotate to make a chain, then rotate
+our new chain into balance.
+
+And it turns out making a chain from knee is easy: choose the middle
+node as the rotation root, the right child as the pivot, and rotate
+counterclockwise. Now the tree looks like $7 \leftarrow 11\leftarrow 17$, and we
+already know how to balance a left chain.
+
+Above, we threw away the right side of the tree by invoking symmetry.
+By invoking symmetry again, we get the right side of the tree back,
+swapping `left' for `right' and `right' for `left.'
+
+
+\paragraph{Why the base cases are important}
+Invoking the property of the AVL tree, inserting a node triggers retracing,
+which may result in rotations to rebalance.  Given random keys, it's
+at least average behavior (I claim!) that an AVL tree is going to rebalance after
+inserting the third node. The chain and knee situations above must be handled
+correctly to proceed with general implementation of AVL tree.
+
+
+\subsection{Rotation beyond the base cases}
+
+The above is all well and good for trees of size 3, which is to say, useless.
+Child nodes are subtrees with possibly very large subtrees of their own,
+and inserting a node which travels all the way to a leaf at the bottom
+of the tree might trigger rotational adjustment all the way back to the
+root of tree. This is less of a problem than it would seem: the base
+case implementation requires one additional concept, that of a
+\textit{swing node} which changes its parent pointer from the pivot to
+the pivot's previous child position on the rotation root. While that
+seems complicated, and may not be exactly trivial, it's a relatively
+straightforward extension of the base case rotation.
+
+That is to say, our new friends chain and knee still control the structure
+of the rotation.
+
+
+\subsection{Retracing}
+
+Retracing is the operation of iterating from the inserted
+node up the tree, possibly (always?) to root, checking
+the balance at each node and rebalancing if necessary.
+Rebalancing is simply applying the correct rotations,
+either the simple right or left, or the double rotations
+as the case may be.
+
+Retracing has three challenges:
+
+\begin{enumerate}
+  \item Determining or maintaining balance factor at each parent,
+  \item distinguishing between ``chain'' and ``knee'' rotations, and
+  \item Ensuring the relationship between the rotation root, the pivot
+    and the rotation root's parent is correct.
+\end{enumerate}
+
+If the weight or ``balance factor'' is maintained at each node, it must be
+adjusted during the rebalancing process. If balance factor isn't maintained at
+each node, the height of each subtree at each node will be required, which is
+expensive.
+
+Some rotations will move the rotation root to a child position, which
+requires resetting its parent to the pivot, and ensuring that the
+pivot and the rotation root's previous parent are linked.
+
+\paragraph{Chain versus knee rotations}
+
+\subsection{Implementation design}
+
+Assuming we want to maintain an accurate node pointer for the root of the tree,
+at the highest level, retracing needs to be controlled by the same data
+structure in charge of the root node. In a node/tree situation, retracing
+belongs to the tree. Since retracing is performed bottom up from the
+inserted node, the tree data structure needs to keep a reference to
+the inserted node, which requires insertion to be controlled by the
+tree as well.
+
+One critical part for correctly implementing an AVL tree's knowledge of
+it's height balance at every node. For example, the reference implementation
+displayed on Wikipedia manages height balance by adjusting the
+\textit{balance factor} on every rotation, and during retracing. That is,
+balance factors are adjusted in two places. The reader is excused if
+he or she finds splitting the work confusing, it is confusing. If possible,
+balance factors should be updated in one place.
+
+\section{Red-black tree}
+
+The Red black-tree appears to have a reputation of being both ``the last word''
+in binary search trees (outside of specialist literature) and a fearsome
+reputation among programmers in practice. One might speculate this reputation
+is founded on the red-black tree being about as complicated as any particular
+undergraduate data structure. For whatever reason, it seems to come up on a
+regular basis in those discussions on what programmers should or should not be
+expected to be proficient in for job interviews. One camp holds that basic data
+structures (i.e., reb-black trees, etc.) should be at a programmer's
+fingertips, the other that book learning from 30 years ago is hardly relevant
+for shipping code daily.
+
+But we don't case about such things. Our interest is in the thing itself.
+
+
 \section{Persistence}
 
 Here are some ways to store the structure in text format:
@@ -906,5 +1090,8 @@ let () =
   run_test_tt_main suite
 ;;
 \end{lstlisting}
+
+To say a child is left or right depends upon who's looking at who.
+Are you looking at the tree? Or is the tree looking at you?
 
 \end{document}

--- a/ruby/.reek.yml
+++ b/ruby/.reek.yml
@@ -58,4 +58,6 @@ exclude_paths:
   - lib/binary_search_tree.rb
   - lib/avl_node.rb
   - lib/stern_brocot.rb
+  - lib/threaded_node.rb
+  - lib/avl_tree.rb
   - vendor/

--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -21,13 +21,15 @@ Metrics/BlockLength:
   Exclude:
     - 'spec/**/*'
 
-ClassLength:
+Metrics/ClassLength:
   Max: 100
   Exclude:
     - lib/node.rb
 
 Layout/LineLength:
   Max: 96
+  Exclude:
+    - 'spec/**/*'
 
 Style/MethodDefParentheses:
   EnforcedStyle: require_parentheses

--- a/ruby/lib/avl_node.rb
+++ b/ruby/lib/avl_node.rb
@@ -3,11 +3,11 @@
 require 'node'
 
 class AvlNode < Node
-  attr_reader :weight
+  attr_accessor :balance_factor
 
   def initialize(key)
     super
-    @weight = 0
+    @balance_factor = 0
   end
 
   def insert_nonworking(node)
@@ -36,20 +36,66 @@ class AvlNode < Node
     @right.nil? ? @right = node : @right.insert(node, self)
   end
 
-  def rotate_cw
+  # def rotate_cw
+  def rotate_right
+    parent = self.parent
+
     pivot = left
     swinger = pivot.right
     self.left = swinger
+    swinger&.parent = left # <- this thing might crash
     pivot.right = self
+    pivot.parent = parent
+    parent&.right = pivot
+    self.parent = pivot
   end
 
-  def rotate_ccw
+  def rotate_left
+    # binding.pry
+    parent = self.parent
+
     pivot = right
     swinger = pivot.left
     self.right = swinger
+    swinger&.parent = right # <- this thing might crash
     pivot.left = self
+    pivot.parent = parent
+    # What we can do here is check to see whether right
+    # or left child of parent.
+    # parent&.left = pivot
+    parent&.right = pivot
+    self.parent = pivot
+    pivot
   end
 
+  def rotate_left_right
+    left.rotate_left
+    rotate_right
+  end
+
+  def rotate_right_left
+    right.rotate_right
+    rotate_left
+  end
+
+  def right_height
+    right.nil? ? 0 : right.height + 1
+  end
+
+  def left_height
+    left.nil? ? 0 : left.height + 1
+  end
+
+  def weight
+    right_height - left_height
+  end
+
+  def balanced?
+    [-1, 0, 1].include? weight
+  end
+
+  # TODO: see if this can punt to the parent Node class.
+  # Move the relevant tests to shared examples.
   def size
     size = 0
     post_order_traverse { size += 1 }

--- a/ruby/lib/avl_tree.rb
+++ b/ruby/lib/avl_tree.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require 'tree'
+require 'avl_node'
+
+class AvlTree < Tree
+  def initialize(node)
+    super
+    root.balance_factor = 0
+  end
+
+  def insert(node)
+    super
+    retrace node
+  end
+
+  # rubocop:disable  Metrics/MethodLength
+  def rotate_left(node, rotation_root)
+    if node.balance_factor.negative?
+      node.rotate_right
+      node.balance_factor += 1
+      node = rotation_root.right
+      node.balance_factor += 1
+    end
+    pivot = rotation_root.rotate_left
+    # ^^^^ This is correct for the rotations on a right chain.
+    rotation_root.balance_factor -= 1
+    pivot.balance_factor -= 1
+    @root = pivot if @root == rotation_root
+    pivot.parent
+  end
+  # rubocop:enable  Metrics/MethodLength
+
+  def rotate_right(node, parent)
+    if node.balance_factor.positive?
+      node.rotate_left
+      node.balance_factor -= 1
+      node = parent.left
+      node.balance_factor -= 1
+    end
+    parent.rotate_right
+    parent.balance_factor += 1
+    @root = node if @root == parent
+    node
+  end
+
+  def balance_right(node)
+    parent = node.parent
+    # parent.balance_factor > 0 ?  rotate_left(node, parent) : parent.balance_factor += 1
+    return rotate_left(node, parent) if parent.balance_factor.positive?
+
+    parent.balance_factor += 1
+    node.parent
+  end
+
+  def balance_left(node)
+    parent = node.parent
+    # parent.balance_factor < 0 ?  rotate_right(node, parent) : parent.balance_factor -= 1
+    return rotate_right(node, parent) if parent.balance_factor.negative?
+
+    parent.balance_factor -= 1
+    node.parent
+  end
+
+  def balance(node)
+    node.right_child? ? balance_right(node) : balance_left(node)
+  end
+
+  def retrace(node)
+    # binding.pry if node.key == 6
+    parent = node.parent
+    until parent.nil?
+      # we need get the current node here, because the node which
+      # gets rotated has it's parent reset, which gums everything up.
+      node = balance(node)
+      # node = parent
+      parent = node&.parent
+    end
+  end
+end

--- a/ruby/lib/node.rb
+++ b/ruby/lib/node.rb
@@ -250,6 +250,10 @@ class Node
     collect []
   end
 
+  def preorder_collect
+    collect_pre_order []
+  end
+
   # TODO: this should be the same with any traverse, each should
   # visit every node once.
   def size

--- a/ruby/lib/threaded_node.rb
+++ b/ruby/lib/threaded_node.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require 'node'
+
+# Create left and right links by calls to successor or
+# predecessor
+class ThreadedNode < Node
+  attr_accessor :left, :right
+end

--- a/ruby/lib/tree.rb
+++ b/ruby/lib/tree.rb
@@ -44,6 +44,9 @@ class Tree
     @root = nil
   end
 
+  # TODO: insert tests, shared examples for tree
+  # AvlTree needs to call super, then call rebalance.
+  # The rebalancing cannot be done via the node insert.
   def insert(node)
     @root.insert node
     @size += 1
@@ -211,7 +214,6 @@ class Tree
   end
 
   def self.from_hash(hash)
-    # Tree.new(Node.build_from_hash(hash))
     Tree.new(NODE_CLASS.build_from_hash(hash))
   end
 

--- a/ruby/spec/avl_fun_and_games_spec.rb
+++ b/ruby/spec/avl_fun_and_games_spec.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+require_relative '../lib/avl_tree'
+
+describe AvlTree do
+  let(:n1) { AvlNode.new 1 }
+  let(:n2) { AvlNode.new 2 }
+  let(:n3) { AvlNode.new 3 }
+  let(:n4) { AvlNode.new 4 }
+  let(:n5) { AvlNode.new 5 }
+  let(:n6) { AvlNode.new 6 }
+  let(:n7) { AvlNode.new 7 }
+  let(:n8) { AvlNode.new 8 }
+  let(:n9) { AvlNode.new 9 }
+  let(:n10) { AvlNode.new 10 }
+  let(:n11) { AvlNode.new 11 }
+  let(:n12) { AvlNode.new 12 }
+  let(:n13) { AvlNode.new 13 }
+  let(:n14) { AvlNode.new 14 }
+  let(:n15) { AvlNode.new 15 }
+
+  context 'counting up' do
+    xit 'results in a perfect tree' do
+      tree = AvlTree.new n1
+
+      tree.insert n2
+      expect(tree.root.balance_factor).to eq 1
+
+      tree.insert n3
+      expect(tree.root.balance_factor).to eq 0
+      expect(tree.root).to eq n2
+      expect(tree.root.left).to eq n1
+      expect(tree.root.right).to eq n3
+
+      tree.insert n4
+      expect(tree.root.balance_factor).to eq 1
+      expect(tree.root.left).to eq n1
+      expect(tree.root.right).to eq n3
+      expect(n3.balance_factor).to eq 1
+      expect(n3.right).to eq n4
+
+      tree.insert n5
+      expect(tree.root).to eq n2
+      expect(tree.root.balance_factor).to eq 1
+      expect(tree.root.left).to eq n1
+      expect(tree.root.right).to eq n4
+      expect(n4.balance_factor).to eq 0
+      expect(n3.balance_factor).to eq 0
+      expect(n4.right).to eq n5
+      expect(n4.left).to eq n3
+
+      tree.insert n6
+      expected = [4, 2, 1, 3, 5, 6]
+      expect(tree.preorder_keys).to eq expected
+      expect(tree.root).to eq n4
+      expect(tree.root.balance_factor).to eq 0
+      expect(n1.balance_factor).to eq 0
+      expect(n2.balance_factor).to eq 0
+      expect(n3.balance_factor).to eq 0
+      expect(n4.balance_factor).to eq 0 # root!
+      expect(n5.balance_factor).to eq 1
+      expect(n6.balance_factor).to eq 0
+
+      # "perfect" tree
+      tree.insert n7
+      expect(tree.height).to eq 2
+      expect(tree.size).to eq 7
+      expected = [4, 2, 1, 3, 6, 5, 7]
+      actual = tree.preorder_keys
+      expect(actual).to eq expected
+
+      tree.insert n8
+      expect(tree.height).to eq 3
+      expect(n7.right).to eq n8
+
+      tree.insert n9
+      expect(tree.height).to eq 3
+      actual = tree.preorder_keys
+      expected = [6, 4, 2, 1, 3, 5, 8, 7, 9]
+      expect(actual).to eq expected
+
+      tree.insert n10
+      expect(tree.height).to eq 3
+      actual = tree.preorder_keys
+      expected = [6, 4, 2, 1, 3, 5, 8, 7, 9, 10]
+      expect(actual).to eq expected
+
+      tree.insert n11
+      # Failing here, the tree rotates too far to the left
+      # making the left side out of balance. This is going to
+      # require working through both the examples on the web
+      # and building examples by hand to figure it out. The
+      # end goal is a perfect tree with 15 nodes, height 3.
+      # I'm pretty sure this is a bookkeeping issue with the
+      # rotations, at least, I'm sure hoping so.
+      #
+      # expect(tree.height).to eq 3
+      actual = tree.preorder_keys
+      puts "actual: #{actual}"
+
+      # This is almost surely not working correctly.
+      # I have a hunch that the other rotation needs to
+      # be fixed so that it will balance properly. Then
+      # again, all the nodes are going in on the far right
+      # so it might correct.
+      tree.insert n12
+      # expect(tree.height).to eq 3
+      tree.insert n13
+      # expect(tree.height).to eq 3
+      tree.insert n14
+      # expect(tree.height).to eq 3
+      tree.insert n15
+      # expect(tree.height).to eq 3
+      actual = tree.preorder_keys
+      puts "actual: #{actual}"
+    end
+  end
+end

--- a/ruby/spec/avl_node_spec.rb
+++ b/ruby/spec/avl_node_spec.rb
@@ -1,113 +1,294 @@
 # frozen_string_literal: true
 
-require_relative '../lib/avl_node'
+require 'spec_helper'
 
-describe AvlNode do
-  describe '.insert' do
-    let(:root) { AvlNode.new 11 }
-    let(:n3) { AvlNode.new 3 }
-    let(:n5) { AvlNode.new(5) }
-    let(:n7) { AvlNode.new 7 }
-    let(:n11) { AvlNode.new 11 }
-    let(:n13) { AvlNode.new 13 }
-    let(:n17) { AvlNode.new 17 }
-    let(:n19) { AvlNode.new 19 }
+require 'shared_examples/insert'
 
-    it 'returns current root on insertion'
+RSpec.describe AvlNode do
+  it_inserts_like 'insertion'
 
-    it 'inserts a node and balances' do
-      n11.insert n5
-      expect(n5.balanced?).to be true
-      expect(n5.weight).to be 0
+  let(:root) { described_class.new 17 }
+  let(:n2) { described_class.new 2 }
+  let(:n5) { described_class.new 5 }
+  let(:n7) { described_class.new 7 }
+  let(:n13) { described_class.new 13 }
+  let(:n19) { described_class.new 19 }
+  let(:n29) { described_class.new 29 }
+
+  xcontext 'rotate' do
+    let(:root) { described_class.new 17 }
+    let(:n11) { described_class.new 11 }
+    let(:n19) { described_class.new 19 }
+    let(:n23) { described_class.new 23 }
+
+    describe '#rotate_left' do
+      context 'right chain' do
+        it "moves the root node to left child\nrotates counterclockwise with 3 nodes right chain" do
+          root.insert n19
+          root.insert n23
+          root.rotate_left
+
+          expected = [19, 17, 23]
+          actual = n19.preorder_collect
+          expect(actual).to eq expected
+          expect(n19.size).to eq 3
+
+          expect(n19.left).to eq root
+          expect(n19.right).to eq n23
+          expect(root.parent).to eq n19
+          expect(n23.parent).to eq n19
+        end
+      end
+
+      it 'rotates counterclockwise' do
+        root = n11
+        root.insert n7
+        n17 = described_class.new 17
+        root.insert n17
+        root.insert n13
+        root.insert n23
+        root.rotate_left
+
+        expect(n17.left).to eq root
+        expect(root.right).to eq n13
+        expect(n17.size).to eq 5
+      end
+
+      context 'right knee' do
+        it 'does a double' do
+          root.insert n29
+          root.insert n23
+          n29.rotate_right
+          first_result = root.preorder_collect
+          expect(first_result).to eq [17, 23, 29]
+          expect(n23.parent).to eq root
+          expect(n29.parent).to eq n23
+          expect(root.right.key).to eq n23.key
+
+          root.rotate_left
+          expected = [23, 17, 29]
+          end_result = n23.preorder_collect
+          expect(end_result).to eq expected
+          expect(n23.left).to eq root
+          expect(n23.right).to eq n29
+          expect(n29.parent).to eq n23
+          expect(root.parent).to eq n23
+        end
+      end
+    end
+
+    describe '#rotate_right' do
+      context 'left chain' do
+        it 'moves the root node to right child' do
+          root.insert n7
+          root.insert n5
+          root.rotate_right
+
+          expected = [7, 5, 17]
+          actual = n7.preorder_collect
+          expect(actual).to eq expected
+          expect(n7.size).to eq 3
+
+          expect(n7.left).to eq n5
+          expect(n7.right).to eq root
+          expect(n5.parent).to eq n7
+          expect(root.parent).to eq n7
+        end
+      end
+
+      it 'rotates clockwise' do
+        root = described_class.new 17
+        n23 = described_class.new 23
+        root.insert n23
+
+        n11 = described_class.new 11
+        n13 = described_class.new 13
+        n7 = described_class.new 7
+        root.insert n11
+        root.insert n13
+        root.insert n7
+
+        root.rotate_right
+        expect(n11.right).to eq root
+        expect(root.left).to eq n13
+        expect(n11.size).to eq 5
+      end
+
+      context 'left knee' do
+        xit 'moves the root node to right child' do
+          root.insert n7
+          root.insert n11
+          n7.rotate_left
+          expect(n11.left).to eq n7
+          expect(root.left).to eq n11
+
+          root.rotate_right
+          actual = n11.preorder_collect
+          expected = [11, 7, 17]
+          expect(actual).to eq expected
+          expect(n7.parent).to eq n11
+          expect(n11.left).to eq n7
+          expect(root.parent).to eq n11
+          expect(n11.right).to eq root
+        end
+      end
+    end
+
+    describe '#rotate_left_right' do
+      context 'left knee' do
+        xit 'moves the root node to right child' do
+          root.insert n7
+          root.insert n11
+          root.rotate_left_right
+
+          expected = [11, 7, 17]
+          actual = n11.preorder_collect
+          expect(actual).to eq expected
+          expect(n7.parent).to eq n11
+          expect(n11.left).to eq n7
+          expect(root.parent).to eq n11
+          expect(n11.right).to eq root
+        end
+      end
+    end
+
+    describe '#rotate_right_left' do
+      context 'right knee' do
+        it 'moves root node to left child' do
+          root.insert n29
+          root.insert n23
+          root.rotate_right_left
+
+          expected = [23, 17, 29]
+          actual = n23.preorder_collect
+          expect(actual).to eq expected
+          expect(n23.left).to eq root
+          expect(n23.right).to eq n29
+          expect(n29.parent).to eq n23
+          expect(root.parent).to eq n23
+        end
+      end
     end
   end
 
-  describe 'rotations' do
-    it 'rotates counterclockwise with 3 nodes right' do
-      root = AvlNode.new 17
-      n23 = AvlNode.new 23
-      n29 = AvlNode.new 29
-      root.insert n23
+  describe '#balanced?' do
+    let(:n11) { described_class.new 11 }
+    let(:n43) { described_class.new 43 }
+
+    it 'is true for node with 0 children' do
+      expect(root.balanced?).to be true
+      expect(root.weight).to eq 0
+    end
+
+    it 'is true for a node with only left child' do
+      root.insert n7
+      expect(root.balanced?).to be true
+      expect(root.weight).to eq(-1)
+    end
+
+    it 'is true for a node with only right child' do
       root.insert n29
-
-      root.rotate_ccw
-      expect(n23.left).to eq root
-      expect(n23.right).to eq n29
-      expect(n23.size).to eq 3
+      expect(root.balanced?).to be true
+      expect(root.weight).to eq 1
     end
 
-    it 'rotates clockwise with 3 nodes left' do
-      root = AvlNode.new 11
-      n5 = AvlNode.new 5
-      n3 = AvlNode.new 3
-      root.insert n5
-      root.insert n3
-      root.rotate_cw
-      expect(n5.right).to eq root
-      expect(n5.left).to eq n3
-      expect(n5.size).to eq 3
+    it 'is true for node with left child and right child' do
+      root.insert n7
+      root.insert n29
+      expect(root.balanced?).to be true
+      expect(root.weight).to eq 0
     end
 
-    it 'rotates clockwise' do
-      root = AvlNode.new 17
-      n23 = AvlNode.new 23
-      root.insert n23
+    it 'is false for node with left chain' do
+      root.insert n7
+      root.insert n2
+      expect(root.balanced?).to be false
+      expect(root.weight).to eq(-2)
+      expect(n7.weight).to eq(-1)
+    end
 
-      n11 = AvlNode.new 11
-      n13 = AvlNode.new 13
-      n7 = AvlNode.new 7
+    it 'is false for node with left knee' do
+      root.insert n7
       root.insert n11
-      root.insert n13
-      root.insert n7
-
-      root.rotate_cw
-      expect(n11.right).to eq root
-      expect(root.left).to eq n13
-      expect(n11.size).to eq 5
+      expect(root.balanced?).to be false
+      expect(root.weight).to eq(-2)
+      expect(n7.weight).to eq(1)
+      expect(root.left.weight).to eq(1)
     end
 
-    it 'rotates counterclockwise' do
-      root = AvlNode.new 11
-      n7 = AvlNode.new 7
-      root.insert n7
-      n17 = AvlNode.new 17
-      n13 = AvlNode.new 13
-      n23 = AvlNode.new 23
-      root.insert n17
-      root.insert n13
-      root.insert n23
+    it 'is false for node with right chain' do
+      root.insert n29
+      root.insert n43
+      expect(root.balanced?).to be false
+      expect(root.weight).to eq 2
+      expect(n29.weight).to eq 1
+    end
 
-      root.rotate_ccw
-      expect(n17.left).to eq root
-      expect(root.right).to eq n13
-      expect(n17.size).to eq 5
+    it 'is false for node with right knee' do
+      root.insert n29
+      root.insert n19
+      expect(root.balanced?).to be false
+      expect(root.weight).to eq 2
+      expect(n29.weight).to eq(-1)
+      expect(root.right.weight).to eq(-1)
+    end
+
+    it 'is true for tree with left bell' do
+      root.insert n29
+      root.insert n7
+      root.insert n11
+      root.insert n5
+      expect(root.balanced?).to be true
+      expect(root.weight).to eq(-1)
+    end
+
+    it 'is true for tree with right bell' do
+      root.insert n7
+      root.insert n29
+      root.insert n19
+      root.insert n43
+      expect(root.balanced?).to be true
+      expect(root.weight).to eq(1)
+    end
+
+    it 'is true for right and left chain at root' do
+      root.insert n7
+      root.insert n19
+      root.insert n5
+      root.insert n29
+      root.insert n2
+      root.insert n43
+      expect(root.balanced?).to be true
+      expect(root.weight).to eq(0)
     end
   end
 
+# rubocop: disable Style/BlockComments
+=begin
   describe 'build avl trees from sorted lists' do
     describe 'trees as linked lists' do
-      let(:n2) { AvlNode.new 2 }
-      let(:n3) { AvlNode.new 3 }
-      let(:n5) { AvlNode.new 5 }
-      let(:n7) { AvlNode.new 7 }
-      let(:n11) { AvlNode.new 11 }
-      let(:n13) { AvlNode.new 13 }
-      let(:n17) { AvlNode.new 17 }
-      let(:n19) { AvlNode.new 19 }
-      let(:n23) { AvlNode.new 23 }
-      let(:n29) { AvlNode.new 29 }
+      let(:n2) { described_class.new 2 }
+      let(:n3) { described_class.new 3 }
+      let(:n5) { described_class.new 5 }
+      let(:n7) { described_class.new 7 }
+      let(:n11) { described_class.new 11 }
+      let(:n13) { described_class.new 13 }
+      let(:n17) { described_class.new 17 }
+      let(:n19) { described_class.new 19 }
+      let(:n23) { described_class.new 23 }
+      let(:n29) { described_class.new 29 }
 
       # Check to ensure the rotations are getting called
       # correctly.
       #
       # Consider having insert return the current root.
       #
-      # expect(n2).to receive(:rotate_ccw).with("correct argument")
+      # expect(n2).to receive(:rotate_left).with("correct argument")
       describe 'only right children' do
         xit 'makes a long right list' do
           n2.insert n3
           n2.insert n5
-          expect(n2).to receive(:rotate_cw) # .with("correct argument")
+          expect(n2).to receive(:rotate_right) # .with("correct argument")
           # expect(n2.height).to eq 1
           # expect(n3.height).to eq 0
           # expect(n3.height).to eq 0
@@ -154,4 +335,6 @@ describe AvlNode do
       end
     end
   end
+=end
+  # rubocop:enable Style/BlockComments
 end

--- a/ruby/spec/avl_tree_spec.rb
+++ b/ruby/spec/avl_tree_spec.rb
@@ -1,0 +1,222 @@
+# frozen_string_literal: true
+
+RSpec.describe AvlTree do
+  let(:root) { AvlNode.new 17 }
+  let(:n11) { AvlNode.new 11 }
+  let(:n19) { AvlNode.new 19 }
+  let(:n23) { AvlNode.new 23 }
+  let(:n7) { AvlNode.new 7 }
+  let(:n2) { AvlNode.new 2 }
+
+  describe 'balance_left' do
+    it 'sets root balance to -1 when single left child' do
+      tree = described_class.new root
+      root.left = n7
+      n7.parent = root
+      tree.balance_left(n7)
+      expect(root.balance_factor).to eq(-1)
+    end
+
+    it 'rotates with left chain' do
+      tree = described_class.new root
+      root.left = n7
+      root.left.left = n2
+      root.balance_factor = -1
+      n2.parent = n7
+      n2.parent.parent = root
+      tree.balance_left(n7)
+      expect(n7.right).to eq root
+      expect(root.parent).to eq n7
+      expect(n7.left).to eq n2
+      expect(tree.root).to eq n7
+    end
+
+    it 'rotates with left knee' do
+      tree = described_class.new root
+      root.left = n7
+      root.left.right = n11
+      root.balance_factor = -1
+      n11.parent = n7
+      n11.parent.parent = root
+      tree.balance_left(n7)
+    end
+  end
+
+  describe '#balance_right' do
+    let(:root) { AvlNode.new 17 }
+    let(:n19) { AvlNode.new 19 }
+    let(:n23) { AvlNode.new 23 }
+
+    it 'sets root balance to 1 when single right child' do
+      tree = described_class.new root
+      root.right = n19
+      n19.parent = root
+      tree.balance_right(n19)
+      expect(root.balance_factor).to eq 1
+    end
+
+    it 'rotates with two right children' do
+      tree = described_class.new root
+      root.right = n19
+      root.right.right = n23
+      root.balance_factor = 1
+      n23.parent = n19
+      n23.parent.parent = root
+      tree.balance_right(n19)
+      expect(tree.root).to eq n19
+    end
+  end
+
+  describe '#retrace' do
+    let(:root) { AvlNode.new 17 }
+
+    context 'left' do
+      it 'finds left child' do
+        tree = AvlTree.new root
+        expect(tree.root.balance_factor).to eq 0
+        tree.root.left = n7
+        n7.parent = tree.root
+        tree.retrace(n7)
+        expect(tree.root.balance_factor).to eq(-1)
+      end
+
+      xit 'finds left left child' do
+        tree = AvlTree.new root
+        expect(tree.root.balance_factor).to eq 0
+        tree.root.left = n7
+        n7.parent = tree.root
+        tree.retrace(n7)
+        expect(tree.root.balance_factor).to eq(-1)
+        n7.left = n2
+        n2.parent = n7
+        tree.retrace(n2)
+
+        expect(tree.root).to eq n7
+        expect(root.parent).to eq n7
+        expect(n7.right).to eq root
+        expect(tree.root.left).to eq n2
+        expect(n2.parent).to eq tree.root
+
+        expect(tree.root.balance_factor).to eq(0)
+        expect(n7.balance_factor).to eq 0
+        expect(root.balance_factor).to eq 0
+      end
+
+      xit 'rotates on left right child' do
+        tree = AvlTree.new root
+        tree.root.left = n2
+        n2.parent = tree.root
+        tree.retrace(n2)
+        expect(tree.root.balance_factor).to eq(-1)
+        n2.right = n7
+        n7.parent = n2
+        tree.retrace(n7)
+
+        expect(tree.root).to eq n7
+        expect(tree.root.right).to eq root
+        expect(root.parent).to eq n7
+        expect(tree.root.left).to eq n2
+        expect(n2.parent).to eq tree.root
+
+        expect(tree.root.balance_factor).to eq 0
+        expect(root.balance_factor).to eq 0
+        expect(n2.balance_factor).to eq 0
+      end
+    end
+
+    context 'right' do
+      it 'finds right child' do
+        tree = AvlTree.new root
+        expect(tree.root.balance_factor).to eq 0
+        tree.root.right = n19
+        n19.parent = tree.root
+        tree.retrace(n19)
+        expect(n19.balance_factor).to eq 0
+        expect(tree.root.balance_factor).to eq 1
+      end
+
+      it 'find right right child' do
+        tree = AvlTree.new root
+        tree.root.right = n19
+        n19.parent = tree.root
+        tree.retrace(n19)
+        expect(tree.root.balance_factor).to eq(1)
+
+        n19.right = n23
+        n23.parent = n19
+        tree.retrace(n23)
+
+        expect(tree.root).to eq n19
+        expect(tree.root.left).to eq root
+        expect(root.parent).to eq n19
+        expect(tree.root.right).to eq n23
+        expect(n23.parent).to eq n19
+
+        expect(tree.root.balance_factor).to eq 0
+        expect(n23.balance_factor).to eq 0
+        expect(root.balance_factor).to eq 0
+      end
+
+      it 'rotates on right left child' do
+        tree = AvlTree.new root
+        tree.root.right = n23
+        n23.parent = tree.root
+        tree.retrace(n23)
+        expect(tree.root.balance_factor).to eq 1
+
+        n23.left = n19
+        n19.parent = n23
+        tree.retrace(n19)
+
+        expect(tree.root.key).to eq 19
+        expect(tree.root.right).to eq n23
+        expect(n23.parent).to eq tree.root
+        expect(tree.root.left).to eq root
+        expect(root.parent).to eq tree.root
+
+        expect(tree.root.balance_factor).to eq 0
+        expect(root.balance_factor).to eq 0
+        expect(n23.balance_factor).to eq 0
+      end
+    end
+  end
+
+  # Yes, these tests are fragile, they're supposed to break if the logic
+  # in the called methods is tampered with. When the called methods need
+  # to change, it's perfectly fine to simply delete these tests.
+  xcontext 'helper method testing to guard against regression' do
+    describe '#balance' do
+      it 'balances right' do
+        tree = AvlTree.new root
+        expect(tree).to receive(:balance_right)
+        tree.insert n19
+      end
+
+      it 'balances left' do
+        tree = AvlTree.new root
+        expect(tree).to receive(:balance_left)
+        tree.insert n7
+      end
+    end
+
+    describe '#balance_right' do
+      it 'rotates left' do
+        tree = AvlTree.new root
+        tree.insert n19
+        expect(tree.root.balance_factor).to eq 1
+        expect(tree).to receive(:rotate_left)
+        tree.insert n23
+      end
+    end
+
+    describe '#balance_left' do
+      it 'rotates right' do
+        tree = AvlTree.new root
+        tree.insert n7
+        expect(tree.root.balance_factor).to eq(-1)
+        expect(tree).to receive(:rotate_right)
+        tree.insert n2
+      end
+    end
+  end
+end

--- a/ruby/spec/node_spec.rb
+++ b/ruby/spec/node_spec.rb
@@ -544,62 +544,6 @@ RSpec.describe Node do
     end
   end
 
-  describe '.balanced?' do
-    let(:root) { Node.new 100 }
-    let(:left) { Node.new 50 }
-    let(:right) { Node.new 150 }
-    let(:l2) { Node.new 25 }
-    let(:l3) { Node.new 75 }
-    let(:l4) { Node.new 15 }
-
-    it 'returns true for node with 0 children' do
-      expect(root.balanced?).to be true
-    end
-
-    it 'returns true for node with 2 children' do
-      root.insert left
-      root.insert right
-      expect(root.balanced?).to be true
-    end
-
-    it 'returns true for a node with only one child' do
-      root.insert left
-      expect(root.balanced?).to be true
-    end
-
-    it 'returns true for tree with 5 nodes' do
-      root.insert left
-      root.insert right
-      root.insert l2
-      root.insert l3
-      expect(root.balanced?).to be true
-    end
-
-    it 'returns nil for tree with 6 nodes' do
-      root.insert left
-      root.insert right
-      root.insert l2
-      root.insert l3
-      root.insert Node.new 145
-      expect(root.balanced?).to be true
-    end
-
-    it 'returns false for long left subtree' do
-      root.insert left
-      root.insert right
-      root.insert l2
-      root.insert l3
-      root.insert l4
-      root.insert Node.new 5
-      expect(root.balanced?).to be false
-    end
-
-    # TODO: insert a bunch more examples here, checking node by node
-    # on an unbalanced tree. Actually, all we really need is a single
-    # tree, then each particular part of the tree can be examined for
-    # balance.
-  end
-
   describe '.bst?' do
     let(:root) { Node.new 17 }
 

--- a/ruby/spec/threaded_node_spec.rb
+++ b/ruby/spec/threaded_node_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require_relative '../lib/threaded_node'
+
+RSpec.describe ThreadedNode do
+  it 'instantiates' do
+    expect(ThreadedNode.new).not_to be nil
+  end
+end


### PR DESCRIPTION
This massive commit message is the result of squashing
over a dozen commits. The original intent was to merge
the branch after correctly implementing AVL tree. Sadly,
a correct implementation is not quite there. To keep
everything efficient and reduce the need for rebasing,
the AVL branch is merged in its incorrect state. Hopefully,
this will make it easier to work on going forward.

avl: rotation spec clarifications

Mostly added a lot of context blocks around
specific rotation specs to better describe
which tree (node arrangement) is being tested.
The existing rotation code seems to work correctly.

avl: start of balance specs

Balancing by retracing is the next step. This commit
provides an initial stab at what the tests should look
like. I have other things to do today, will fill remaining
tests and implementation later.

There is an overhead associated with computing the
height on demand. I hesitate to memoize it as the
tree will change height at any node over its
lifespan.

avl: more example specs

Along with adding more examples, there is a marker
for working through the mechanics of the recursion
on insert. It's pretty interesting, and not exactly
how I though it would work. Could be as much as a
day's work to go through how the stack works with
respect to arguments passed into the recursing
method, which is overloaded, btw, we're calling super,
that's the interesting part.

avl: placeholder commit, need to refactor spec on master

The insertion for avl needs to move from node to tree,
which really needs to leverage some refactoring of
the specs, which should really be done in master.
So committing here and hopefully the rebase won't
collide with any of the code already on this branch.

avl: initial rebalancing for left chain

Seems to work correctly. I tried to implement
using the code on Wikipedia as a template, but
that code is far too messy for me to understand.
So I'm working it out on my own on paper for
special cases, and implementing by these cases.

avl: naming clean up for semantic congruence

Changed several method names in the rebalancing
procedure to better reflect what the methods are doing.

Specifically, "rebalance" is now "retrace," and only
traverses up the parent pointers, invoking the "balance"
method each iteration. Much easier to understand. At
least for me.

avl: so-called double rotation implemented

The double rotation operation is very simple to
implement by composing the two single rotations
opposing each other. The key is using the correct
rotation roots for each.

avl: cleaned up naming convention for rotation

The names for the rotation methods are now very
simple: rotate_[left|right[_[right|left]]. An
alternative scheme would have been to stick
with clockwise and counterclockwise, but the
abbreviations "cw" and "ccw" aren't descriptive
enough, and spelling it out makes for very long
method names.

avl: "knee" rotation case from tree retracing

I think this is the commit which finishes the tree
insertion which handles retracing and rebalancing
correctly.

The main thing I've gotten out of this is that the
references I've been using make it more difficult
than it really is, primarily because they all use
large functions which do too much.

There is also the notion of returning an updated
root node from a rotation. This may be a useful notion,
and worth investigating in more detail.