### PR TITLE
BST-39 ruby exception for key not found

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -20,6 +20,7 @@ pdfs: $(PDFS)
 
 zips: $(ZIPS)
 
+bst: bst.pdf
 
 # PREAMBLE = ../preamble.tex
 

--- a/doc/bst.tex
+++ b/doc/bst.tex
@@ -12,8 +12,8 @@
 \maketitle
 
 \abstract{A few notes on binary search trees and their implementations
-in various programming languages. While theory is not neglected, implementation
-details are preeminent.}
+in various programming languages. Theory and implementation details are
+given equal treatment.}
 
 \tableofcontents
 
@@ -257,6 +257,44 @@ call delete after the node is orphaned.
 Abstract data structures such as binary search trees support a standard
 set of operations including insertion, deletion, search, etc. A closer look
 at each of these operations follows.
+
+\subsection{Least common ancestor}
+
+The \textit{least common ancestor} (LCA) of two nodes $v$ and $w$ in a tree $T$ is the
+lowest or deepest node which has $v$ and $w$ as descendants of itself, and where
+each node is defined as a descendant of itself. The LCA is the shared ancestor located
+farthest from the root of the tree $T$. Consider the following 3 node binary search tree.
+
+\begin{tikzpicture}[level/.style={sibling distance=50mm/#1}]
+  \node [circle,draw] (z){$2$}
+    child {node [circle,draw] (a) {$1$}}
+    child {node [circle,draw] (j) {$3$}
+  };
+\end{tikzpicture}
+
+We have the following cases:
+
+\begin{enumerate}
+  \item 1 is the LCA of 1.
+  \item 2 is the LCA of 2.
+  \item 3 is the LCA of 3.
+  \item 2 is the LCA of 1 and 3.
+  \item 2 is the LCA of 2 and 3.
+  \item 2 is the LCA of 1 and 2.
+\end{enumerate}
+
+At least two algorithms may be employed to determine LCA. The first algorithm makes
+two passes through $T$ to find a path from the root to the node. The second makes a
+single pass through $T$, once down each branch.
+
+For the first algorithm, implementing a path to node method is not difficult as
+it uses the same mechanics as the find method.
+
+\subsubsection{Error conditions}
+
+The LCA algorithms fails if either node is not present in $T$. Handling this
+condition is implementation dependent.
+
 
 \subsection{Depth-first traverse}
 

--- a/ruby/lib/node.rb
+++ b/ruby/lib/node.rb
@@ -10,6 +10,9 @@ class NodeCsvWriter
 end
 
 class Node
+  class KeyNotFoundError < ::StandardError
+  end
+
   attr_accessor :parent, :left, :right, :uuid, :key, :visited
 
   INCR = 1
@@ -146,7 +149,9 @@ class Node
 
     # We may not actually care about the returned node, but if we
     # want to generalize `find` this method needs to work if the
-    # node is returned.
+    # node is returned. Also, if there is no node with the associated
+    # key, the `find` will return nil, which can be raised as a
+    # KeyNotFoundError
     return self if key == @key
 
     key < @key ? left&.find(key, &block) : right&.find(key, &block)
@@ -154,7 +159,9 @@ class Node
   # rubocop:enable Metrics/CyclomaticComplexity
 
   def path_to_node(key, collector)
-    find(key) { |node| collector << node.key }
+    node = find(key) { |n| collector << n.key }
+    raise KeyNotFoundError if node.nil?
+
     collector
   end
 

--- a/ruby/spec/node_path_spec.rb
+++ b/ruby/spec/node_path_spec.rb
@@ -85,6 +85,13 @@ RSpec.describe Node do
         path = tree.root.path_to_root(2, [])
         expect(path).to eq [2, 1, 3]
       end
+
+      it 'handles key not present' do
+        tree = Generator.tree312
+        expect do
+          tree.root.path_to_root(13, [])
+        end.to raise_error(Node::KeyNotFoundError)
+      end
     end
   end
 
@@ -130,6 +137,13 @@ RSpec.describe Node do
       tree = Generator.tree10
       path = tree.root.path_to_node(23, [])
       expect(path).to eq [11, 13, 19, 29, 23]
+    end
+
+    it 'use the generator 10 for key not present' do
+      tree = Generator.tree10
+      expect do
+        tree.root.path_to_node(123, [])
+      end.to raise_error(Node::KeyNotFoundError)
     end
 
     context 'the size 3 trees' do


### PR DESCRIPTION
Node::KeyNotFoundError added, implemented in `path_to_node`.
It should probably be used everywhere else which depends on
keys being in the tree.

Documentation for LCA updated.