### PR TITLE
BST-44 create a yaml fixture directory at repo root

### DIFF
--- a/fixtures/README.md
+++ b/fixtures/README.md
@@ -1,0 +1,6 @@
+# Binary Search Tree fixtures
+
+Normally, test fixtures would go into a directory
+structure local to a specific implementation. In this
+case, a set of fixtures common to all implementations
+is useful.

--- a/fixtures/tree1.yml
+++ b/fixtures/tree1.yml
@@ -1,0 +1,5 @@
+---
+key: 11
+uuid: uuid
+left:
+right:

--- a/fixtures/tree10.yml
+++ b/fixtures/tree10.yml
@@ -1,0 +1,41 @@
+---
+key: 11
+uuid: uuid
+left:
+  key: 7
+  uuid: uuid
+  left:
+    key: 3
+    uuid: uuid
+    left:
+      key: 2
+      uuid: uuid
+      left:
+      right:
+    right:
+      key: 5
+      uuid: uuid
+      left:
+      right:
+  right:
+right:
+  key: 13
+  uuid: uuid
+  left:
+  right:
+    key: 19
+    uuid: uuid
+    left:
+      key: 17
+      uuid: uuid
+      left:
+      right:
+    right:
+      key: 29
+      uuid: uuid
+      left:
+        key: 23
+        uuid: uuid
+        left:
+        right:
+      right:

--- a/fixtures/tree123.yml
+++ b/fixtures/tree123.yml
@@ -1,0 +1,13 @@
+---
+key: 1
+uuid: uuid
+left:
+right:
+  key: 2
+  uuid: uuid
+  left:
+  right:
+    key: 3
+    uuid: uuid
+    left:
+    right:

--- a/fixtures/tree132.yml
+++ b/fixtures/tree132.yml
@@ -1,0 +1,13 @@
+---
+key: 1
+uuid: uuid
+left:
+right:
+  key: 3
+  uuid: uuid
+  left:
+    key: 2
+    uuid: uuid
+    left:
+    right:
+  right:

--- a/fixtures/tree2.yml
+++ b/fixtures/tree2.yml
@@ -1,0 +1,9 @@
+---
+key: 11
+uuid: uuid
+left:
+  key: 7
+  uuid: uuid
+  left:
+  right:
+right:

--- a/fixtures/tree213.yml
+++ b/fixtures/tree213.yml
@@ -1,0 +1,13 @@
+---
+key: 2
+uuid: uuid
+left:
+  key: 1
+  uuid: uuid
+  left:
+  right:
+right:
+  key: 3
+  uuid: uuid
+  left:
+  right:

--- a/fixtures/tree3.yml
+++ b/fixtures/tree3.yml
@@ -1,0 +1,13 @@
+---
+key: 11
+uuid: uuid
+left:
+  key: 7
+  uuid: uuid
+  left:
+  right:
+right:
+  key: 13
+  uuid: uuid
+  left:
+  right:

--- a/fixtures/tree312.yml
+++ b/fixtures/tree312.yml
@@ -1,0 +1,13 @@
+---
+key: 3
+uuid: uuid
+left:
+  key: 1
+  uuid: uuid
+  left:
+  right:
+    key: 2
+    uuid: uuid
+    left:
+    right:
+right:

--- a/fixtures/tree321.yml
+++ b/fixtures/tree321.yml
@@ -1,0 +1,13 @@
+---
+key: 3
+uuid: uuid
+left:
+  key: 2
+  uuid: uuid
+  left:
+    key: 1
+    uuid: uuid
+    left:
+    right:
+  right:
+right:

--- a/fixtures/tree4.yml
+++ b/fixtures/tree4.yml
@@ -1,0 +1,17 @@
+---
+key: 11
+uuid: uuid
+left:
+  key: 7
+  uuid: uuid
+  left:
+    key: 3
+    uuid: uuid
+    left:
+    right:
+  right:
+right:
+  key: 13
+  uuid: uuid
+  left:
+  right:

--- a/fixtures/tree5.yml
+++ b/fixtures/tree5.yml
@@ -1,0 +1,21 @@
+---
+key: 11
+uuid: uuid
+left:
+  key: 7
+  uuid: uuid
+  left:
+    key: 3
+    uuid: uuid
+    left:
+    right:
+  right:
+right:
+  key: 13
+  uuid: uuid
+  left:
+  right:
+    key: 19
+    uuid: uuid
+    left:
+    right:

--- a/fixtures/tree6.yml
+++ b/fixtures/tree6.yml
@@ -1,0 +1,25 @@
+---
+key: 11
+uuid: uuid
+left:
+  key: 7
+  uuid: uuid
+  left:
+    key: 3
+    uuid: uuid
+    left:
+    right:
+  right:
+right:
+  key: 13
+  uuid: uuid
+  left:
+  right:
+    key: 19
+    uuid: uuid
+    left:
+    right:
+      key: 29
+      uuid: uuid
+      left:
+      right:

--- a/fixtures/tree7.yml
+++ b/fixtures/tree7.yml
@@ -1,0 +1,29 @@
+---
+key: 11
+uuid: uuid
+left:
+  key: 7
+  uuid: uuid
+  left:
+    key: 3
+    uuid: uuid
+    left:
+    right:
+      key: 5
+      uuid: uuid
+      left:
+      right:
+  right:
+right:
+  key: 13
+  uuid: uuid
+  left:
+  right:
+    key: 19
+    uuid: uuid
+    left:
+    right:
+      key: 29
+      uuid: uuid
+      left:
+      right:

--- a/fixtures/tree8.yml
+++ b/fixtures/tree8.yml
@@ -1,0 +1,33 @@
+---
+key: 11
+uuid: uuid
+left:
+  key: 7
+  uuid: uuid
+  left:
+    key: 3
+    uuid: uuid
+    left:
+      key: 2
+      uuid: uuid
+      left:
+      right:
+    right:
+      key: 5
+      uuid: uuid
+      left:
+      right:
+  right:
+right:
+  key: 13
+  uuid: uuid
+  left:
+  right:
+    key: 19
+    uuid: uuid
+    left:
+    right:
+      key: 29
+      uuid: uuid
+      left:
+      right:

--- a/fixtures/tree9.yml
+++ b/fixtures/tree9.yml
@@ -1,0 +1,37 @@
+---
+key: 11
+uuid: uuid
+left:
+  key: 7
+  uuid: uuid
+  left:
+    key: 3
+    uuid: uuid
+    left:
+      key: 2
+      uuid: uuid
+      left:
+      right:
+    right:
+      key: 5
+      uuid: uuid
+      left:
+      right:
+  right:
+right:
+  key: 13
+  uuid: uuid
+  left:
+  right:
+    key: 19
+    uuid: uuid
+    left:
+      key: 17
+      uuid: uuid
+      left:
+      right:
+    right:
+      key: 29
+      uuid: uuid
+      left:
+      right:

--- a/ruby/lib/generator.rb
+++ b/ruby/lib/generator.rb
@@ -5,72 +5,72 @@ require_relative './node'
 
 class Generator
   class << self
-    def build(nodes)
-      tree = Tree.new(Node.new(nodes.shift))
-      nodes.each { |n| tree.insert(Node.new(n)) }
+    def build(nodes, uuid)
+      tree = Tree.new(Node.new(nodes.shift, uuid))
+      nodes.each { |n| tree.insert(Node.new(n, uuid)) }
       tree
     end
 
-    def tree1
-      Generator.build [11]
+    def tree1(uuid = nil)
+      Generator.build [11], uuid
     end
 
-    def tree2
-      Generator.build [11, 7]
+    def tree2(uuid = nil)
+      Generator.build [11, 7], uuid
     end
 
-    def tree3
-      Generator.build [11, 7, 13]
+    def tree3(uuid = nil)
+      Generator.build [11, 7, 13], uuid
     end
 
-    def tree4
-      Generator.build [11, 7, 13, 3]
+    def tree4(uuid = nil)
+      Generator.build [11, 7, 13, 3], uuid
     end
 
-    def tree5
-      Generator.build [11, 7, 13, 3, 19]
+    def tree5(uuid = nil)
+      Generator.build [11, 7, 13, 3, 19], uuid
     end
 
-    def tree6
-      Generator.build [11, 7, 13, 3, 19, 29]
+    def tree6(uuid = nil)
+      Generator.build [11, 7, 13, 3, 19, 29], uuid
     end
 
-    def tree7
-      Generator.build [11, 7, 13, 3, 19, 29, 5]
+    def tree7(uuid = nil)
+      Generator.build [11, 7, 13, 3, 19, 29, 5], uuid
     end
 
-    def tree8
-      Generator.build [11, 7, 13, 3, 19, 29, 5, 2]
+    def tree8(uuid = nil)
+      Generator.build [11, 7, 13, 3, 19, 29, 5, 2], uuid
     end
 
-    def tree9
-      Generator.build [11, 7, 13, 3, 19, 29, 5, 2, 17]
+    def tree9(uuid = nil)
+      Generator.build [11, 7, 13, 3, 19, 29, 5, 2, 17], uuid
     end
 
-    def tree10
-      Generator.build [11, 7, 13, 3, 19, 29, 5, 2, 17, 23]
+    def tree10(uuid = nil)
+      Generator.build [11, 7, 13, 3, 19, 29, 5, 2, 17, 23], uuid
     end
 
     # These could go into yaml files in spec/fixtures, or even in a
     # globally accessible file for use by all implementations.
-    def tree213
-      Generator.build [2, 1, 3]
+    def tree213(uuid = nil)
+      Generator.build [2, 1, 3], uuid
     end
 
-    def tree123
-      Generator.build [1, 2, 3]
+    def tree123(uuid = nil)
+      Generator.build [1, 2, 3], uuid
     end
 
-    def tree132
-      Generator.build [1, 3, 2]
+    def tree132(uuid = nil)
+      Generator.build [1, 3, 2], uuid
     end
 
-    def tree321
-      Generator.build [3, 2, 1]
+    def tree321(uuid = nil)
+      Generator.build [3, 2, 1], uuid
     end
 
-    def tree312
-      Generator.build [3, 1, 2]
+    def tree312(uuid = nil)
+      Generator.build [3, 1, 2], uuid
     end
   end
 end

--- a/ruby/lib/tree.rb
+++ b/ruby/lib/tree.rb
@@ -196,6 +196,22 @@ class Tree
     root.to_hash
   end
 
+  def to_yml
+    require 'yaml'
+    to_hash.to_yaml
+  end
+
+  def to_yaml_file(filename)
+    File.open(filename, 'w') { |file| file.write(to_yml) }
+  end
+
+  # TODO: BST-44 finish up here
+  def self.from_yaml_file(filename)
+    require 'yaml'
+    hashed = YAML.safe_load(File.read(filename))
+    from_hash(hashed)
+  end
+
   def to_json(*_args)
     root.to_json
   end

--- a/ruby/spec/output/yml/tree3.yml
+++ b/ruby/spec/output/yml/tree3.yml
@@ -1,0 +1,13 @@
+---
+key: 11
+uuid: uuid
+left:
+  key: 7
+  uuid: uuid
+  left:
+  right:
+right:
+  key: 13
+  uuid: uuid
+  left:
+  right:

--- a/ruby/spec/tree_spec.rb
+++ b/ruby/spec/tree_spec.rb
@@ -257,7 +257,7 @@ RSpec.describe Tree do
       end
     end
 
-    describe '.to_json' do
+    describe '#to_json' do
       it 'creates json representation of tree' do
         root = Node.new(8)
         allow(root).to receive(:uuid).and_return('uuid')
@@ -267,7 +267,7 @@ RSpec.describe Tree do
       end
     end
 
-    describe '.to_json_file' do
+    describe '#to_json_file' do
       it 'writes json to a file' do
         require 'open3'
         filename = 'tree_with_nodes.json'
@@ -286,6 +286,57 @@ RSpec.describe Tree do
 
         saved_tree = Tree.from_json_file '/tmp/tree.json'
         expect(saved_tree.root.uuid).to eq tree.root.uuid
+      end
+    end
+
+    context 'yaml' do
+      describe '.to_yml' do
+        it 'returns yaml representation of tree' do
+          allow_any_instance_of(Node).to receive(:uuid).and_return('uuid')
+          tree = Generator.tree3
+          expected = <<~TREE
+            ---
+            key: 11
+            uuid: uuid
+            left:
+              key: 7
+              uuid: uuid
+              left:
+              right:
+            right:
+              key: 13
+              uuid: uuid
+              left:
+              right:
+          TREE
+
+          expect(tree.to_yml).to eq expected
+        end
+      end
+
+      describe '.to_yaml_file' do
+        it 'writes file identical to existing fixture' do
+          allow_any_instance_of(Node).to receive(:uuid).and_return('uuid')
+          tree = Generator.tree3
+          require 'open3'
+          filename = 'tree3.yml'
+          tree.to_yaml_file "/tmp/#{filename}"
+          diff = "diff /tmp/#{filename} ../fixtures/#{filename}"
+          output, _status = Open3.capture2e(diff)
+
+          expect(output.empty?).to be true
+        end
+      end
+
+      describe '#from_yaml_file' do
+        it 'successfully round trips a tree through yaml persistence' do
+          tree = Generator.tree3
+          filename = '/tmp/tree.yml'
+          tree.to_yaml_file(filename)
+          saved = Tree.from_yaml_file(filename)
+
+          expect(saved.root.uuid).to eq tree.root.uuid
+        end
       end
     end
 


### PR DESCRIPTION
From the README:

Normally, test fixtures would go into a directory
structure local to a specific implementation. In this
case, a set of fixtures common to all implementations
is useful.

This commit uses the Ruby implementation as an initial
proof of concept. The Ruby tree Generator class was used
to create the initial yaml fixtures.

Note that Ruby has a built-in `to_yaml` method for objects.
The decision here is to not override that method, but
instead implement `to_yml` to store just the data for each
tree, without any of the Ruby metadata associated with
the Ruby built-in `to_yaml`.