### PR TITLE
BST-77 javascript invert binary tree

### DIFF
--- a/js/lib/node.js
+++ b/js/lib/node.js
@@ -103,7 +103,7 @@ Node.prototype.post_order_traverse = function(callback) {
   if (this.right !== null) {
     this.right.post_order_traverse(callback);
   }
-  callback();
+  callback(this);
 };
 
 Node.prototype.size = function() {
@@ -112,6 +112,22 @@ Node.prototype.size = function() {
     size++;
   });
   return size;
+};
+
+Node.prototype.invert = function() {
+  // console.log(`this.left: ${this.left}, this.right: ${this.right}`);
+
+  this.post_order_traverse(function(node) {
+    // console.log(`before swap node.key: ${node.key}`);
+    // console.log(`before swap node.left: ${node.left}`);
+    // console.log(`before swap node.right: ${node.right}`);
+
+    let swap = node.left;
+    node.left = node.right;
+    // console.log(`node.left after swap: ${node.left}`);
+    node.right = swap;
+    // console.log(`node.right after swap: ${node.right}`);
+  });
 };
 
 Node.prototype.successor = function(node) {

--- a/js/spec/node_spec.js
+++ b/js/spec/node_spec.js
@@ -440,4 +440,75 @@ describe('Node', function() {
       assert.strictEqual(n23.is_unlinked(), true);
     });
   });
+
+  describe('invert', () => {
+    it('inverts a single node', () => {
+      const root = new node(17);
+      root.invert();
+      assert.strictEqual(root.left, null);
+      assert.strictEqual(root.right, null);
+    });
+
+    it('inverts root with left node', () => {
+      let root = new node(17);
+      const n5 = new node(5);
+      root.insert(n5);
+      root.invert();
+
+      assert.strictEqual(root.left, null);
+      assert.strictEqual(root.right, n5);
+    });
+
+    it('inverts root with right node', () => {
+      let root = new node(17);
+      const n23 = new node(23);
+      root.insert(n23);
+      root.invert();
+
+      assert.strictEqual(root.left, n23);
+      assert.strictEqual(root.right, null);
+    });
+
+    it('inverts root with left and right nodes', () => {
+      let root = new node(17);
+      const n5 = new node(5);
+      const n23 = new node(23);
+      root.insert(n5);
+      root.insert(n23);
+      root.invert();
+
+      assert.strictEqual(root.left, n23);
+      assert.strictEqual(root.right, n5);
+    });
+
+    it('inverts full tree of depth two', () => {
+      let root = new node(17);
+      // left branch
+      const n11 = new node(11);
+      const n5 = new node(5);
+      const n13 = new node(13);
+      root.insert(n11);
+      root.insert(n13);
+      root.insert(n5);
+
+      // right branch
+      const n23 = new node(23);
+      const n17 = new node(17);
+      const n29 = new node(29);
+      root.insert(n23);
+      root.insert(n29);
+      root.insert(n17);
+
+      root.invert();
+
+      assert.strictEqual(root.left, n23);
+      assert.strictEqual(root.right, n11);
+
+      assert.strictEqual(n11.left, n13);
+      assert.strictEqual(n11.right, n5);
+
+      assert.strictEqual(n23.left, n29);
+      assert.strictEqual(n23.right, n17);
+    });
+  });
 });


### PR DESCRIPTION
Inverting according to definition given on Leetcode,
which is to swap left and right subtrees at every node.

Scoping `this` becaome an issue, hence the update to
the post order traverse call back. Commented out console
logging is left in for now, will be removed in a future
commit.

The lack of standard examples and tooling for property-
based testing slowed this work down. All languages
implementations need this.