### PR TITLE
BST-111 read from yaml in elixir test

### DIFF
--- a/elixir/mix.exs
+++ b/elixir/mix.exs
@@ -20,6 +20,9 @@ defmodule Bst.Mixfile do
 
   # Type "mix help deps" for more examples and options
   defp deps do
-    [{:credo, "~>0.7", only: [:test, :dev]}]
+    [
+      {:credo, "~>0.7", only: [:test, :dev]},
+      {:yaml_elixir, "~> 2.7.0"},
+    ]
   end
 end

--- a/elixir/mix.lock
+++ b/elixir/mix.lock
@@ -1,2 +1,6 @@
-%{"bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm"},
-  "credo": {:hex, :credo, "0.7.3", "9827ab04002186af1aec014a811839a06f72aaae6cd5eed3919b248c8767dbf3", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}], "hexpm"}}
+%{
+  "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm", "7af5c7e09fe1d40f76c8e4f9dd2be7cebd83909f31fee7cd0e9eadc567da8353"},
+  "credo": {:hex, :credo, "0.7.3", "9827ab04002186af1aec014a811839a06f72aaae6cd5eed3919b248c8767dbf3", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}], "hexpm", "c13121d559cb2c19251c48fca3d409285e3fc0aa2d97edb40682753b3503bd5d"},
+  "yamerl": {:hex, :yamerl, "0.8.1", "07da13ffa1d8e13948943789665c62ccd679dfa7b324a4a2ed3149df17f453a4", [:rebar3], [], "hexpm", "96cb30f9d64344fed0ef8a92e9f16f207de6c04dfff4f366752ca79f5bceb23f"},
+  "yaml_elixir": {:hex, :yaml_elixir, "2.7.0", "6f731d622a3b28769e26e634f82aa171d1d01cae0e8820ce9e93e559c83c23c8", [:mix], [{:yamerl, "~> 0.8", [hex: :yamerl, repo: "hexpm", optional: false]}], "hexpm", "f2eb39e0fb23625777f74e0c821f42f033dc4eaa5402c34beaa665944d85f3ea"},
+}

--- a/elixir/test/bst_test.exs
+++ b/elixir/test/bst_test.exs
@@ -2,11 +2,16 @@ defmodule BstTest do
   use ExUnit.Case
   doctest Bst
 
-  test "the truth" do
-    assert 1 + 1 == 2
-  end
-
   test 'testem' do
     assert Bst.Node.testem == 'testem'
+  end
+
+  test 'read yaml fixture' do
+    path = Path.join(File.cwd!(), "../fixtures/tree1.yml")
+    expected = {:ok, %{"key" => 11, "left" => nil, "right" => nil, "uuid" => "uuid"}}
+    actual = YamlElixir.read_from_file(path)
+    IO.inspect(actual)
+
+    assert actual == expected
   end
 end


### PR DESCRIPTION
This is just a proof of concept to ensure the elixir
code can read from existing fixtures.

Some dependencies needed to be updated to be able to
complie the tests, those updates are rolled into this
change as well.