### PR TITLE
BST-76 ruby invert method

### DIFF
--- a/ruby/lib/node.rb
+++ b/ruby/lib/node.rb
@@ -36,7 +36,15 @@ class Node
     @key > other.key
   end
 
-  # add a callback (monad?) for duplicate key handling
+  # For insertion, we specifically use an instantiated node,
+  # then look for the correct place to place the node in the
+  # tree. Another way to do it would be to instantiate the node
+  # at the point where the key should be inserted. The problem
+  # with that is it makes it difficult to associate a value with
+  # the key. Instantiating the node with its key, and potentially
+  # a value is easier before executing insertion.
+  #
+  # TODO: add a callback (monad?) for duplicate key handling
   def insert(node)
     node < self ? insert_left(node) : insert_right(node)
   end
@@ -147,6 +155,15 @@ class Node
   end
   # rubocop:enable Metrics/MethodLength
 
+  # a classic operation for interviews
+  def invert
+    post_order_traverse do |node|
+      tmp = node.right
+      node.right = node.left
+      node.left = tmp
+    end
+  end
+
   # TODO: refactor to use a block, then with find.
   # https://doolin.atlassian.net/browse/BST-36
   def find_with_parent(key, parent)
@@ -180,6 +197,9 @@ class Node
   def path_to_root(key, collector)
     path_to_node(key, collector).reverse
   end
+
+  # PROPERTIES below here
+  # TODO: rearrange the class into an operations section and a properties section
 
   def present?(key)
     find(key) ? true : false

--- a/ruby/spec/invert_spec.rb
+++ b/ruby/spec/invert_spec.rb
@@ -1,0 +1,61 @@
+# frozen-string-literal: true
+
+RSpec.describe Node do
+  describe '#invert' do
+    it 'nil case unsupported on Node' do
+      # this doesn't work with an instance method invert
+    end
+
+    it 'base case for single node' do
+      tree = Generator.tree1
+      tree.root.invert
+
+      aggregate_failures do
+        expect(tree.root.left).to be nil
+        expect(tree.root.right).to be nil
+      end
+    end
+
+    it 'two node tree with left only swaps to right' do
+      tree = Generator.tree2
+      tree.root.invert
+
+      aggregate_failures do
+        expect(tree.root.left).to be nil
+        expect(tree.root.right.key).to be 7
+      end
+    end
+
+    it 'two node tree with right only swaps to left' do
+      tree = Generator.build([11, 13], 'invert')
+      tree.root.invert
+
+      aggregate_failures do
+        expect(tree.root.left.key).to be 13
+        expect(tree.root.right).to be nil
+      end
+    end
+
+    it 'root with left and right nodes swaps children.' do
+      tree = Generator.tree213
+      tree.root.invert
+
+      aggregate_failures do
+        expect(tree.root.left.key).to be 3
+        expect(tree.root.right.key).to be 1
+      end
+    end
+
+    context 'inverting generated trees reverse sorts the keys' do
+      %i[tree1 tree2 tree3 tree4 tree5 tree6 tree7 tree8 tree9 tree10].each do |t|
+        example "for #{t}" do
+          tree = Generator.send t
+          sorted = tree.list_keys
+          tree.root.invert
+
+          expect(tree.list_keys).to eq sorted.reverse
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
A recent classic interview question. Because I took the
time to build a post-order traverse, it's as simple as
passing a block to the traverse which swaps left and right
children. That is it.

What's interesting is that this also reverses the sorting
from in-order traverse.