### PR TITLE
BST-152 fix avl perfect tree spec

### DIFF
--- a/ruby/lib/avl_node.rb
+++ b/ruby/lib/avl_node.rb
@@ -24,15 +24,13 @@ class AvlNode < Node
     # node may have to change to ensure balance.
   end
 
-  # def rotate_cw
   def rotate_right
-    # if parent is nil, then the parent needs to be the right node.
     parent = self.parent
 
     pivot = left
     swinger = pivot.right
     self.left = swinger
-    swinger&.parent = left # <- this thing might crash
+    swinger&.parent = left
     pivot.right = self
     pivot.parent = parent
     parent&.right = pivot
@@ -41,13 +39,12 @@ class AvlNode < Node
   end
 
   def rotate_left
-    # if parent is nil, then the parent needs to be the right node.
     parent = self.parent
 
     pivot = right
     swinger = pivot.left
     self.right = swinger
-    swinger&.parent = right # <- this thing might crash
+    swinger&.parent = right
     pivot.left = self
     pivot.parent = parent
     parent&.left = pivot

--- a/ruby/lib/avl_tree.rb
+++ b/ruby/lib/avl_tree.rb
@@ -46,7 +46,6 @@ class AvlTree < Tree
 
   def balance_right(node)
     parent = node.parent
-    # parent.balance_factor > 0 ?  rotate_left(node, parent) : parent.balance_factor += 1
     return rotate_left(node, parent) if parent.balance_factor.positive?
 
     parent.balance_factor += 1
@@ -55,7 +54,6 @@ class AvlTree < Tree
 
   def balance_left(node)
     parent = node.parent
-    # parent.balance_factor < 0 ?  rotate_right(node, parent) : parent.balance_factor -= 1
     return rotate_right(node, parent) if parent.balance_factor.negative?
 
     parent.balance_factor -= 1
@@ -67,13 +65,9 @@ class AvlTree < Tree
   end
 
   def retrace(node)
-    # binding.pry # if node.key == 6
     parent = node.parent
     until parent.nil?
-      # we need get the current node here, because the node which
-      # gets rotated has it's parent reset, which gums everything up.
       node = balance(node)
-      # node = parent
       parent = node&.parent
     end
   end

--- a/ruby/spec/avl_fun_and_games_spec.rb
+++ b/ruby/spec/avl_fun_and_games_spec.rb
@@ -19,73 +19,128 @@ RSpec.describe AvlTree do
   let(:n14) { AvlNode.new 14 }
   let(:n15) { AvlNode.new 15 }
 
-  context 'counting up' do
-    xit 'results in a perfect tree' do
-      tree = AvlTree.new n1
+  def build_tree(size)
+    tree = AvlTree.new(AvlNode.new(1))
+    (2..size).to_a.each { |n| tree.insert(AvlNode.new(n)) }
+    tree
+  end
 
-      tree.insert n2
+  context 'builds trees of size' do
+    example '1' do
+      tree = build_tree(1)
+      expect(tree.preorder_keys).to eq [1]
+    end
+
+    example '2' do
+      tree = build_tree(2)
       expect(tree.root.balance_factor).to eq 1
+      expect(tree.root.right.balance_factor).to eq 0
+      expect(tree.preorder_keys).to eq [1, 2]
+    end
 
-      tree.insert n3
+    example '3' do
+      tree = build_tree(3)
+
       expect(tree.root.balance_factor).to eq 0
-      expect(tree.root).to eq n2
-      expect(tree.root.left).to eq n1
-      expect(tree.root.right).to eq n3
+      expect(tree.root.left.balance_factor).to eq 0
+      expect(tree.root.right.balance_factor).to eq 0
 
+      expect(tree.root.key).to eq 2
+      expect(tree.root.left.key).to eq 1
+      expect(tree.root.right.key).to eq 3
+
+      expect(tree.preorder_keys).to eq [2, 1, 3]
+    end
+  end
+
+  context 'counting up' do
+    it 'keys 1-4 are balanced correctly' do
+      tree = AvlTree.new n1
+      tree.insert n2
+      tree.insert n3
       tree.insert n4
+      # TODO: write a preorder traverse which collects balance_factor from each node.
       expect(tree.root.balance_factor).to eq 1
+      expect(tree.root.right.balance_factor).to eq 1
+      expect(tree.root.right.right.balance_factor).to eq 0
+      expect(n3.balance_factor).to eq 1
+
+      expect(tree.root.left.balance_factor).to eq 0
+
       expect(tree.root.left).to eq n1
       expect(tree.root.right).to eq n3
-      expect(n3.balance_factor).to eq 1
       expect(n3.right).to eq n4
+      expect(tree.preorder_keys).to eq [2, 1, 3, 4]
+    end
+
+    xit 'inserting key 5' do
+      tree = AvlTree.new n1
+      tree.insert n2
+      tree.insert n3
+      tree.insert n4
+      expect(tree.preorder_keys).to eq [2, 1, 3, 4]
 
       tree.insert n5
       expect(tree.root).to eq n2
-      expect(tree.root.balance_factor).to eq 1
-      expect(tree.root.left).to eq n1
-      expect(tree.root.right).to eq n4
-      expect(n4.balance_factor).to eq 0
-      expect(n3.balance_factor).to eq 0
-      expect(n4.right).to eq n5
-      expect(n4.left).to eq n3
 
-      tree.insert n6
-      expected = [4, 2, 1, 3, 5, 6]
-      expect(tree.preorder_keys).to eq expected
-      expect(tree.root).to eq n4
-      expect(tree.root.balance_factor).to eq 0
-      expect(n1.balance_factor).to eq 0
-      expect(n2.balance_factor).to eq 0
-      expect(n3.balance_factor).to eq 0
-      expect(n4.balance_factor).to eq 0 # root!
-      expect(n5.balance_factor).to eq 1
-      expect(n6.balance_factor).to eq 0
+      # TODO: this is where I go next, from a balanced 2, 1, 3, 4 tree
+      # to the following. The way to do this is walk through the various
+      # rotations manually, keeping track of state at every step of the
+      # way. At some point, I will find the place where the actual state
+      # is not what I'm expecting, and that's where I'll start modifying.
+      # I expect getting this working is going to require a pretty good
+      # overhaul of the current implementation.
+      #
+      # Also, I should manually write out the the current result before
+      # attempting to fix it.
+      expect(tree.preorder_keys).to eq [2, 1, 4, 3, 5]
+      # expect(tree.root.balance_factor).to eq 1
+      # expect(tree.root.left).to eq n1
+      # expect(tree.root.right).to eq n4
+      # expect(n4.balance_factor).to eq 0
+      # expect(n3.balance_factor).to eq 0
+      # expect(n4.right).to eq n5
+      # expect(n4.left).to eq n3
+    end
+
+    xit 'counting past 5' do
+      # tree.insert n6
+      # expected = [4, 2, 1, 3, 5, 6]
+      # expect(tree.preorder_keys).to eq expected
+      # expect(tree.root).to eq n4
+      # expect(tree.root.balance_factor).to eq 0
+      # expect(n1.balance_factor).to eq 0
+      # expect(n2.balance_factor).to eq 0
+      # expect(n3.balance_factor).to eq 0
+      # expect(n4.balance_factor).to eq 0 # root!
+      # expect(n5.balance_factor).to eq 1
+      # expect(n6.balance_factor).to eq 0
 
       # "perfect" tree
-      tree.insert n7
-      expect(tree.height).to eq 2
-      expect(tree.size).to eq 7
-      expected = [4, 2, 1, 3, 6, 5, 7]
-      actual = tree.preorder_keys
-      expect(actual).to eq expected
+      # tree.insert n7
+      # expect(tree.height).to eq 2
+      # expect(tree.size).to eq 7
+      # expected = [4, 2, 1, 3, 6, 5, 7]
+      # actual = tree.preorder_keys
+      # expect(actual).to eq expected
 
-      tree.insert n8
-      expect(tree.height).to eq 3
-      expect(n7.right).to eq n8
+      # tree.insert n8
+      # expect(tree.height).to eq 3
+      # expect(n7.right).to eq n8
 
-      tree.insert n9
-      expect(tree.height).to eq 3
-      actual = tree.preorder_keys
-      expected = [6, 4, 2, 1, 3, 5, 8, 7, 9]
-      expect(actual).to eq expected
+      # tree.insert n9
+      # expect(tree.height).to eq 3
+      # actual = tree.preorder_keys
+      # expected = [6, 4, 2, 1, 3, 5, 8, 7, 9]
+      # expect(actual).to eq expected
 
-      tree.insert n10
-      expect(tree.height).to eq 3
-      actual = tree.preorder_keys
-      expected = [6, 4, 2, 1, 3, 5, 8, 7, 9, 10]
-      expect(actual).to eq expected
+      # tree.insert n10
+      # expect(tree.height).to eq 3
+      # actual = tree.preorder_keys
+      # expected = [6, 4, 2, 1, 3, 5, 8, 7, 9, 10]
+      # expect(actual).to eq expected
 
-      tree.insert n11
+      # tree.insert n11
       # Failing here, the tree rotates too far to the left
       # making the left side out of balance. This is going to
       # require working through both the examples on the web
@@ -95,24 +150,24 @@ RSpec.describe AvlTree do
       # rotations, at least, I'm sure hoping so.
       #
       # expect(tree.height).to eq 3
-      actual = tree.preorder_keys
-      puts "actual: #{actual}"
+      # actual = tree.preorder_keys
+      # puts "actual: #{actual}"
 
       # This is almost surely not working correctly.
       # I have a hunch that the other rotation needs to
       # be fixed so that it will balance properly. Then
       # again, all the nodes are going in on the far right
       # so it might correct.
-      tree.insert n12
-      # expect(tree.height).to eq 3
-      tree.insert n13
-      # expect(tree.height).to eq 3
-      tree.insert n14
-      # expect(tree.height).to eq 3
-      tree.insert n15
-      # expect(tree.height).to eq 3
-      actual = tree.preorder_keys
-      puts "actual: #{actual}"
+      # tree.insert n12
+      # # expect(tree.height).to eq 3
+      # tree.insert n13
+      # # expect(tree.height).to eq 3
+      # tree.insert n14
+      # # expect(tree.height).to eq 3
+      # tree.insert n15
+      # # expect(tree.height).to eq 3
+      # actual = tree.preorder_keys
+      # puts "actual: #{actual}"
     end
   end
 end


### PR DESCRIPTION
A full fix did not happen in this commit. However,
the spec in question was cleaned up a bit, as was
several other parts of the code, namely removing
stale comments.

Getting the spec to work will likely require rewriting
of the rotation and balancing implementation, which could
be really tedious. Hopefully, the pattern established in
this change will make those reimplementations a bit easier
and more reliable.