### PR TITLE
BST-166 build Nodes recursively from dictionary representing a tree

### DIFF
--- a/python/lib/node.py
+++ b/python/lib/node.py
@@ -1,3 +1,7 @@
+import pdb
+from typing import Type
+
+
 class Node(object):
     def __init__(self, key):
         self.key = key
@@ -225,3 +229,46 @@ class Node(object):
             return self
         else:
             return self.left.minimum()
+
+    @classmethod
+    def from_dict(cls, tree_dict) -> Type["Node"]:
+        """
+        Build a (sub)tree recursively from a dict.
+
+        The recursion proceeds in pre-order traverse, as each
+        node will have a key, but may not have any children. This
+        function will filter out unecessary keys in the dict.
+
+        Note: there are no checks for dict correctness, the binary
+        search tree structure is assumed to be correct within the dict.
+
+        TODO:
+            1. Ensure type hinting for the return value is correct.
+            2. Add type hinting to the tree_dict argument.
+            3. Improve the structure of the testing.
+            4. Consider moving this to its own file or function.
+
+        Parameters:
+            cls: per @classmethod convention
+            tree_dict: a correctly structured binary search tree
+
+        Returns:
+            Node: at the conclusion of the recursion, the returned node
+            will represent the root of the tree as defined by the dict
+            which was passed as an argument.
+        """
+        if tree_dict is None:
+            return None
+
+        if not tree_dict:
+            return None
+
+        node = Node(tree_dict["key"])
+
+        if tree_dict["left"] is not None:
+            node.left = cls.from_dict(tree_dict["left"])
+
+        if tree_dict["right"] is not None:
+            node.right = cls.from_dict(tree_dict["right"])
+
+        return node

--- a/python/test/node_test.py
+++ b/python/test/node_test.py
@@ -238,6 +238,58 @@ class TestNode(unittest.TestCase):
         assert root.predecessor(n3) == n2
         assert n2.predecessor(n2) == n2
 
+    # pipenv run pytest test/node_test.py -k test_from_dict -vvrP
+    def test_from_dict(self):
+        tree = None
+        result = Node.from_dict(tree)
+        assert result is None
+
+        tree = {}
+        result = Node.from_dict(tree)
+        assert result is None
+
+        tree = {"key": 11, "uuid": "uuid", "left": None, "right": None}
+        result = Node.from_dict(tree)
+        assert result.key == 11
+
+        tree = {
+            "key": 11,
+            "uuid": "uuid",
+            "left": {"key": 7, "left": None, "right": None, "uuid": "uuid"},
+            "right": None,
+        }
+        result = Node.from_dict(tree)
+        assert result.key == 11
+        assert result.left.key == 7
+
+        tree = {
+            "key": 11,
+            "uuid": "uuid",
+            "left": {"key": 7, "left": None, "right": None, "uuid": "uuid"},
+            "right": {"key": 13, "left": None, "right": None, "uuid": "uuid"},
+        }
+        result = Node.from_dict(tree)
+        assert result.key == 11
+        assert result.left.key == 7
+        assert result.right.key == 13
+
+        tree = {
+            "key": 11,
+            "uuid": "uuid",
+            "left": {
+                "key": 7,
+                "left": {"key": 3, "left": None, "right": None, "uuid": "uuid"},
+                "right": None,
+                "uuid": "uuid",
+            },
+            "right": {"key": 13, "left": None, "right": None, "uuid": "uuid"},
+        }
+        result = Node.from_dict(tree)
+        assert result.key == 11
+        assert result.left.key == 7
+        assert result.left.left.key == 3
+        assert result.right.key == 13
+
     def tearDown(self):
         self.testing = False
 


### PR DESCRIPTION
Given a correctly structured dict containing a binary search tree,
the Node class will recursively pre-order traverse the dict,
returning a root node with the top level key.