### PR TITLE
BST-190 Fix broken lua specs around table building

### DIFF
--- a/lua/lib/node.lua
+++ b/lua/lib/node.lua
@@ -206,11 +206,11 @@ function build_from_table(tbl)
   -- element. In other words, lyaml seems to parse "left:\n" as `left = { nil }`
   -- It may or may not be worth catching this further upstream, but that
   -- may be more work than it's worth.
-  if (tbl.left ~= nil and tbl.left['left'] ~= nil) then
+  if (tbl.left ~= nil and tbl.left['key'] ~= nil) then
     node.left = build_from_table(tbl.left)
   end
 
-  if (tbl.right ~= nil and tbl.right['right'] ~= nil) then
+  if (tbl.right ~= nil and tbl.right['key'] ~= nil) then
     node.right = build_from_table(tbl.right)
   end
 

--- a/lua/spec/node_spec.lua
+++ b/lua/spec/node_spec.lua
@@ -25,7 +25,7 @@ describe("#build_from_table", function()
     assert.are.same(tree, one)
   end)
 
-  it("builds 213 tree from a table", function()
+  it("builds #213 tree from a table", function()
     local three = {
       key = 3,
       left = nil,


### PR DESCRIPTION
Building a table in Lua can be tricky as, for example,
the lyaml library may in certain circumstances initialize
a key with an empty table instead of an nil value.