### PR TITLE
BST-214 Remove unused methods from binary search tree module spec

### DIFF
--- a/ruby/spec/binary_search_tree_spec.rb
+++ b/ruby/spec/binary_search_tree_spec.rb
@@ -19,14 +19,6 @@ class Foo
     @key < other.key
   end
 
-  def >=(other)
-    @key >= other.key
-  end
-
-  def >(other)
-    @key > other.key
-  end
-
   def <=(other)
     @key <= other.key
   end


### PR DESCRIPTION
Another really small commit. This is to remove code which is
not covered with the spec. Since the methods aren't needed,
it's better to delete them rather than writing superfluous
specs. Adding them back in would be trivial.