### PR TITLE
BST-180 Create fixtures for full BSTs

### DIFF
--- a/doc/bst-properties.tex
+++ b/doc/bst-properties.tex
@@ -66,7 +66,7 @@ Keys are assumed to be unique.
 
 \subsection{Diameter}
 
-\subsection{Class}
+\subsection{Classification}
 
 Binary search trees may be classified according to the
 arrangement of the leaves and internal nodes.

--- a/doc/examples.tex
+++ b/doc/examples.tex
@@ -490,5 +490,33 @@ A binary search tree using first 10 primes for keys:
 \path (r) -- (c) node [midway] {$\cdots$};
 \end{tikzpicture}}
 
+\vspace{1in}
+\hrule
+
+\section{Binary Tree template}
+
+
+\begin{tikzpicture}[scale=1.0,level/.style={sibling distance=50mm/#1}]
+  \node [circle,draw] (z){$16$}
+    child {node [circle,draw] (a) {$\phantom{0}8$}
+      child {node [circle,draw] (b) {$04$}
+        child {node [circle, draw] (c) {$02$}}
+        child {node [circle, draw] (d) {$06$}}
+      }
+      child {node [circle,draw] (g) {$12$}
+        child {node [circle, draw] (ga) {$10$}}
+        child {node [circle,draw] (gb) {$14$}
+          child {node [circle,draw] (gd) {$13$}}
+          child {node [circle,draw] (gc) {$15$}}
+        }
+      }
+    }
+    child {node [circle,draw] (j) {$24$}
+      child {node [circle,draw] (k) {$20$}}
+    child {node [circle,draw] (l) {$28$}}
+  };
+\end{tikzpicture}
+
+
 
 \end{document}

--- a/fixtures/full/tree1.yml
+++ b/fixtures/full/tree1.yml
@@ -1,0 +1,5 @@
+---
+key: 2
+uuid: uuid
+left:
+right:

--- a/fixtures/full/tree3.yml
+++ b/fixtures/full/tree3.yml
@@ -1,0 +1,13 @@
+---
+key: 2
+uuid: uuid
+left:
+  key: 1
+  uuid: uuid
+  left:
+  right:
+right:
+  key: 3
+  uuid: uuid
+  left:
+  right:

--- a/fixtures/full/tree5.yml
+++ b/fixtures/full/tree5.yml
@@ -1,0 +1,21 @@
+---
+key: 8
+uuid: uuid
+left:
+  key: 4
+  uuid: uuid
+  left:
+  right:
+right:
+  key: 12
+  uuid: uuid
+  left:
+    key: 10
+    uuid: uuid
+    left:
+    right:
+  right:
+    key: 14
+    uuid: uuid
+    left:
+    right:

--- a/fixtures/full/tree5_left.yml
+++ b/fixtures/full/tree5_left.yml
@@ -1,0 +1,21 @@
+---
+key: 8
+uuid: uuid
+left:
+  key: 4
+  uuid: uuid
+  left:
+    key: 2
+    uuid: uuid
+    left:
+    right:
+  right:
+    key: 6
+    uuid: uuid
+    left:
+    right:
+right:
+  key: 12
+  uuid: uuid
+  left:
+  right:

--- a/fixtures/full/tree5_right.yml
+++ b/fixtures/full/tree5_right.yml
@@ -1,0 +1,21 @@
+---
+key: 8
+uuid: uuid
+left:
+  key: 4
+  uuid: uuid
+  left:
+  right:
+right:
+  key: 12
+  uuid: uuid
+  left:
+    key: 10
+    uuid: uuid
+    left:
+    right:
+  right:
+    key: 14
+    uuid: uuid
+    left:
+    right:

--- a/fixtures/full/tree7.yml
+++ b/fixtures/full/tree7.yml
@@ -1,0 +1,29 @@
+---
+key: 8
+uuid: uuid
+left:
+  key: 4
+  uuid: uuid
+  left:
+  right:
+right:
+  key: 12
+  uuid: uuid
+  left:
+    key: 10
+    uuid: uuid
+    left:
+      key: 9
+      uuid: uuid
+      left:
+      right:
+    right:
+      key: 11
+      uuid: uuid
+      left:
+      right:
+  right:
+    key: 14
+    uuid: uuid
+    left:
+    right:

--- a/fixtures/full/tree9.yml
+++ b/fixtures/full/tree9.yml
@@ -1,0 +1,37 @@
+---
+key: 8
+uuid: uuid
+left:
+  key: 4
+  uuid: uuid
+  left:
+    key: 2
+    uuid: uuid
+    left:
+    right:
+  right:
+    key: 6
+    uuid: uuid
+    left:
+    right:
+right:
+  key: 12
+  uuid: uuid
+  left:
+    key: 10
+    uuid: uuid
+    left:
+      key: 9
+      uuid: uuid
+      left:
+      right:
+    right:
+      key: 11
+      uuid: uuid
+      left:
+      right:
+  right:
+    key: 14
+    uuid: uuid
+    left:
+    right:

--- a/ruby/bin/full
+++ b/ruby/bin/full
@@ -1,0 +1,22 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require_relative '../lib/generator'
+
+tree = Generator.build([2], 'uuid')
+tree.to_yaml_file('../fixtures/full/tree1.yml')
+
+tree = Generator.build([2, 1, 3], 'uuid')
+tree.to_yaml_file('../fixtures/full/tree3.yml')
+
+tree = Generator.build([8, 4, 12, 10, 14], 'uuid')
+tree.to_yaml_file('../fixtures/full/tree5_right.yml')
+
+tree = Generator.build([8, 4, 2, 6, 12], 'uuid')
+tree.to_yaml_file('../fixtures/full/tree5_left.yml')
+
+tree = Generator.build([8, 4, 12, 10, 14, 9, 11], 'uuid')
+tree.to_yaml_file('../fixtures/full/tree7.yml')
+
+tree = Generator.build([8, 4, 2, 6, 12, 10, 14, 9, 11], 'uuid')
+tree.to_yaml_file('../fixtures/full/tree9.yml')

--- a/ruby/readme.md
+++ b/ruby/readme.md
@@ -5,7 +5,6 @@ with a coworker, a self-taught programmer with a background in
 Russian literature. We both agreed we needed to step it up a bit,
 and binary search trees seemed like an excellent place to start.
 
-
 ## Finding a node
 
 In a really simple case, the node key and value can be the same.
@@ -39,18 +38,30 @@ recursive, overriding with iteration as necessary. The
 naming pattern for these subclasses will follow the pattern
 `IterativeTree`, `IterativeNode`, and so on.
 
+## Make trees super fast
+
+The `Generator` class can be used to make trees really fast. Here's an example:
+
+1. `cd ruby`
+1. `irb`
+1. `require_relative './lib/generator'`
+1. `tree = Generator.build([7, 5, 13, 11, 15], "uuid")`
+1. `tree.to_yaml_file('../fixtures/full/tree5.yml')`
+
+This creates a full binary search tree and writes it to a yaml file.
+
 ## TODO
 
-* Create a simple data structure to store, subclass `Struct`
-* Add  `node.key` and use value for some associated data object
-* (DONE) Test for node not present in a tree.
-* Refactor the comparator specs in `node_spec.rb`
+- Create a simple data structure to store, subclass `Struct`
+- Add `node.key` and use value for some associated data object
+- (DONE) Test for node not present in a tree.
+- Refactor the comparator specs in `node_spec.rb`
 
 ## References
 
-* [Wikipedia](https://en.wikipedia.org/wiki/Binary_search_tree), because
+- [Wikipedia](https://en.wikipedia.org/wiki/Binary_search_tree), because
   there's no shame in simply getting started however which way, and
   Wikipedia is free for everyone.
-* [CLR](https://www.amazon.com/Introduction-Algorithms-3rd-MIT-Press/dp/0262033844/) Gold standard.
-* [Skienna](https://www.amazon.com/Algorithm-Design-Manual-Steven-Skiena/dp/B00B8139Z8/),
-a very useful reference with readable exposition and a unique slant.
+- [CLR](https://www.amazon.com/Introduction-Algorithms-3rd-MIT-Press/dp/0262033844/) Gold standard.
+- [Skienna](https://www.amazon.com/Algorithm-Design-Manual-Steven-Skiena/dp/B00B8139Z8/),
+  a very useful reference with readable exposition and a unique slant.

--- a/ruby/spec/tree_spec.rb
+++ b/ruby/spec/tree_spec.rb
@@ -474,6 +474,48 @@ RSpec.describe Tree do
             # expect(tree.pathological??).to be true
           end
         end
+
+        context 'full trees from yaml' do
+          let(:yaml_dir) { '../fixtures/full' }
+
+          it 'tree1' do
+            tree = Tree.from_yaml_file("#{yaml_dir}/tree1.yml")
+            expect(tree.size).to eq 1
+            expect(tree.height).to eq 0
+            expect(tree.bst?).to be true
+            expect(tree.full?).to be true
+            expect(tree.balanced?).to be true
+            expect(tree.postorder_keys).to eq [2]
+            expect(tree.preorder_keys).to eq [2]
+            # expect(tree1.pathological??).to be false
+          end
+
+          it 'tree3' do
+            tree = Tree.from_yaml_file("#{yaml_dir}/tree3.yml")
+            expect(tree.root.size).to eq 3
+            expect(tree.height).to eq 1
+            expect(tree.bst?).to be true
+            expect(tree.full?).to be true
+            expect(tree.balanced?).to be true
+            expect(tree.postorder_keys).to eq [1, 3, 2]
+            expect(tree.preorder_keys).to eq [2, 1, 3]
+            expect(tree.inorder_keys).to eq [1, 2, 3]
+            # expect(tree1.pathological??).to be false
+          end
+
+          it 'tree5' do
+            tree = Tree.from_yaml_file("#{yaml_dir}/tree5.yml")
+            expect(tree.root.size).to eq 5
+            expect(tree.height).to eq 2
+            expect(tree.bst?).to be true
+            expect(tree.full?).to be true
+            expect(tree.balanced?).to be true
+            expect(tree.postorder_keys).to eq [4, 10, 14, 12, 8]
+            expect(tree.preorder_keys).to eq [8, 4, 12, 10, 14]
+            expect(tree.inorder_keys).to eq [4, 8, 10, 12, 14]
+            # expect(tree1.pathological??).to be false
+          end
+        end
       end
     end
 


### PR DESCRIPTION
In the quest to implement algorithm for determining all
properties and operations, this change provides a common
set of fixtures for full binary search trees described in
yaml, using the defined from the cited references.

Some really interesting structure emerges when the consective
integers are sorted into a binary search tree in a particular.
More details in a later commit.