### PR TITLE
BST-228 libyaml build and test infrastructure

### DIFF
--- a/c/configure.ac
+++ b/c/configure.ac
@@ -20,6 +20,7 @@ AC_PROG_CC
 # FIXME: Replace `main' with a function in `-lboost_unit_test_framework':
 AC_CHECK_LIB([boost_unit_test_framework], [main])
 
+AC_CHECK_LIB([yaml], [main])
 
 # FIXME: Replace `main' with a function in `-lcppunit':
 AC_CHECK_LIB([cppunit], [main])

--- a/c/include/yaml.h
+++ b/c/include/yaml.h
@@ -1,0 +1,17 @@
+#ifndef IS_BST_YAML_H
+#define IS_BST_YAML_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "node.h"
+
+// TODO: return Tree
+Node * load_tree(FILE * yaml_file);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // IS_BST_YAML_H

--- a/c/src/.gitignore
+++ b/c/src/.gitignore
@@ -1,8 +1,9 @@
-Makefile
 *.a
+Makefile
 gmon.out
 *.o
 .deps
 *~
 yaml
 getsome
+yaml

--- a/c/src/Makefile.am
+++ b/c/src/Makefile.am
@@ -6,14 +6,17 @@ CPPFLAGS = -Wall -Wextra
 AM_CPPFLAGS = -I/usr/local/include -I../include
 
 noinst_LIBRARIES = libbst.a
-libbst_a_SOURCES = node.c tree.c collector.c
+libbst_a_SOURCES = node.c tree.c collector.c yaml.c
 # libbst_a_CPPFLAGS = -O0 -pg  -Wall -Wextra -fno-inline $(AM_CPPFLAGS) -DIL_STD -L/usr/local/lib -DNDEBUG -w
+# -pg enables gprof, see https://stackoverflow.com/questions/4981121/how-exactly-does-gprof-work/5046039#5046039
+# TODO: figure out what NDEBUG is for, I have forgotten.
 libbst_a_CFLAGS = -O0 -pg  -Wall -Wextra -fno-inline $(AM_CPPFLAGS) -DIL_STD -L/usr/local/lib -DNDEBUG -w
 
 
-# bin_PROGRAMS = getsome
-# getsome_SOURCES = main.cpp
-# getsome_CPPFLAGS = -O0 -pg  -Wall -Wextra -fno-inline $(AM_CPPFLAGS) -DIL_STD -L/usr/local/lib #-DNDEBUG -w -finstrument-functions-exclude-file-list=iostream.h,string.h,vector.h
-# getsome_LDFLAGS = -pg  -O0
-# getsome_LDADD = -L. -lbst
+bin_PROGRAMS = yaml
+yaml_SOURCES = yaml.c
+yaml_CPPFLAGS = -O0 -pg  -Wall -Wextra -fno-inline $(AM_CPPFLAGS) -DIL_STD -L/usr/local/lib -DSTANDALONE #-DNDEBUG -w -finstrument-functions-exclude-file-list=iostream.h,string.h,vector.h
+yaml_LDFLAGS = -pg  -O0
+yaml_LDFLAGS = -O0
+yaml_LDADD = ./libbst.a
 

--- a/c/src/node_private.h
+++ b/c/src/node_private.h
@@ -5,6 +5,7 @@
 
 struct _node {
   int key;
+  char uuid[100];
   Node * left;
   Node * right;
   Node * parent;

--- a/c/src/yaml.c
+++ b/c/src/yaml.c
@@ -1,0 +1,34 @@
+#include <stdio.h>
+#include <yaml.h>
+
+#include "node.h"
+
+Node * load_tree(FILE * yaml_file) {
+  Node * root_node = NULL;
+
+  return root_node;
+}
+
+#ifdef STANDALONE
+Node * display_yaml(void) {
+  FILE *yaml_file = fopen("../../fixtures/tree10.yml", "r");
+  Node * node = load_tree(yaml_file);
+  fclose(yaml_file);
+  return node;
+}
+
+int main(void) {
+  Node * node = display_yaml();
+  // printf("node root location: %p\n", node);
+  // printf("node key: %d\n", node->key);
+  // printf("node left location: %p\n", node->left);
+  // printf("node right location: %p\n", node->right);
+  // printf("node left key: %d\n", node->left->key);
+  // printf("node right key: %d\n", node->right->key);
+  // Collector * collector = collector_new(100);
+  // node_collect(node, collector);
+  // collector_printf(collector);
+  // collector_destroy(collector);
+  return 0;
+}
+#endif // STANDALONE

--- a/c/test/.gitignore
+++ b/c/test/.gitignore
@@ -2,6 +2,8 @@ collector
 initial
 node
 tree
+yaml
+*.orig
 *.o
 *.gch
 *~

--- a/c/test/Makefile.am
+++ b/c/test/Makefile.am
@@ -1,18 +1,19 @@
 AM_CXXFLAGS = -std=c++11 -Wall -Wextra  -Wno-unused-parameter
-AM_CPPFLAGS = -I../include -I. $(shell cppunit-config --cflags)
+AM_CPPFLAGS = -I../include # -I. $(shell cppunit-config --cflags)
 
 # AM_LDFLAGS = $(shell cppunit-config --libs)
 # Not used with clang at the moment, save it in case
-AM_LDFLAGS = $(shell cppunit-config --libs) -L/usr/local/Cellar/boost/1.62.0/lib/
+AM_LDFLAGS = -L/usr/local/Cellar/boost/1.62.0/lib/ # $(shell cppunit-config --libs) 
 LDADD = ../src/libbst.a
 
 %.o: %.cpp
 	g++ $(AM_CXXFLAGS) $(AM_CPPFLAGS) -D$*_STANDALONE -c $< $(AM_LDFLAGS)
 
-bin_PROGRAMS = node tree collector
+bin_PROGRAMS = node tree collector yaml
 
 node_SOURCES = test_node.cpp testutils.cpp
 tree_SOURCES = test_tree.cpp testutils.cpp
 collector_SOURCES = test_collector.cpp testutils.cpp
+yaml_SOURCES = test_yaml.cpp testutils.cpp
 
 

--- a/c/test/colortest.h
+++ b/c/test/colortest.h
@@ -1,6 +1,8 @@
 #ifndef INVENTIUM_COLORTEST_H
 #define INVENTIUM_COLORTEST_H
 
+// xterm colors: https://jonasjacek.github.io/colors/
+
 #define  COLOR16 "\33[38;5;16m"
 #define  COLOR17 "\33[38;5;17m"
 #define  COLOR18 "\33[38;5;18m"

--- a/c/test/test_yaml.cpp
+++ b/c/test/test_yaml.cpp
@@ -1,0 +1,54 @@
+#include <string>
+
+#include <cppunit/TestCase.h>
+#include "./testutils.h"
+
+#include <node.h>
+#include <collector.h>
+#include <yaml.h>
+#include "../src/node_private.h"
+
+using std::string;
+
+class YamlTest : public CppUnit::TestCase {
+
+  public:
+  YamlTest( std::string name ) : CppUnit::TestCase( name ) {}
+
+  void test_dummy() {
+    describe_test(INDENT0, "Dummy yaml test");
+    
+    Spec spec;
+
+    spec.it("does nothing", DO_SPEC_HANDLE {
+      FILE *yaml_file = fopen("../../fixtures/tree10.yml", "r");
+      Node * node = load_tree(yaml_file);
+      fclose(yaml_file);
+      return true;
+    });
+
+
+  }
+
+  void run_tests(void) {
+    //setup();
+    test_dummy();
+    //teardown();
+  }
+
+};
+
+void
+test_yaml() {
+
+  YamlTest * yt = new YamlTest(std::string("initial test"));
+  yt->run_tests();
+  delete yt;
+}
+
+int
+main(int argc, char ** argv) {
+
+  test_yaml();
+  return 0;
+}

--- a/c/test/testutils.h
+++ b/c/test/testutils.h
@@ -9,8 +9,8 @@
 
 #include "colortest.h"
 
-#define DESCCOLOR COLOR45
-#define PASSCOLOR COLOR119
+#define DESCCOLOR COLOR25
+#define PASSCOLOR COLOR36
 #define FAILCOLOR COLOR124
 #define PENDINGCOLOR COLOR166
 

--- a/elixir/test/bst_test.exs
+++ b/elixir/test/bst_test.exs
@@ -9,7 +9,7 @@ defmodule BstTest do
   # also, configure credo: https://hexdocs.pm/credo/config_file.html
   test 'read yaml fixture' do
     path = Path.join(File.cwd!(), "../fixtures/tree1.yml")
-    expected = {:ok, %{"key" => 11, "left" => nil, "right" => nil, "uuid" => "uuid"}}
+    expected = {:ok, %{"key" => 11, "left" => nil, "right" => nil, "uuid" => "uuid11"}}
     actual = YamlElixir.read_from_file(path)
     # IO.inspect(actual, limit: :infinity)
     # IO.inspect(actual)

--- a/fixtures/tree1.yml
+++ b/fixtures/tree1.yml
@@ -1,5 +1,5 @@
 ---
 key: 11
-uuid: uuid
+uuid: uuid11
 left:
 right:

--- a/fixtures/tree2.yml
+++ b/fixtures/tree2.yml
@@ -1,9 +1,9 @@
 ---
 key: 11
-uuid: uuid
+uuid: uuid11
 left:
   key: 7
-  uuid: uuid
+  uuid: uuid7
   left:
   right:
 right:

--- a/ruby/lib/node.rb
+++ b/ruby/lib/node.rb
@@ -374,6 +374,7 @@ class Node
     node
   end
 
+  # This is implicitely pre-order traverse.
   def to_hash
     {
       'key' => key,


### PR DESCRIPTION
These changes support biulding and testing a libyaml wrapper
to extract a BST defined in a yaml file. No actual yaml pro-
cessing occurs, but the test code compiles, a standalone
executable compiles, and the interface is exposed.