### PR TITLE
BST-47 libyaml testing structure

### DIFF
--- a/c/include/yaml.h
+++ b/c/include/yaml.h
@@ -10,6 +10,8 @@ extern "C" {
 // TODO: return Tree
 Node * load_tree(FILE * yaml_file);
 
+Node * from_yaml(char * filename);
+
 #ifdef __cplusplus
 }
 #endif

--- a/c/src/node.c
+++ b/c/src/node.c
@@ -37,7 +37,6 @@ in_order_traverse(Node * n, Callback callback, void * userdata) {
   }
 }
 
-
 Node *
 node_new(int key) {
   Node * n = calloc(1, sizeof(Node));
@@ -77,7 +76,6 @@ int
 node_key(Node * n) {
   return n->key;
 }
-
 
 Node *
 node_left(Node * n) {

--- a/c/src/yaml.c
+++ b/c/src/yaml.c
@@ -2,10 +2,191 @@
 #include <yaml.h>
 
 #include "node.h"
+#include "collector.h"
+#include "node_private.h"
+
+// This link provides a demonstration for what I want to do:
+// https://github.com/meffie/libyaml-examples/blob/master/parse.c
+// I forked it to Inventium just in case:
+// https://github.com/Inventium/libyaml-examples
+//
+// libcyaml source: https://github.com/tlsa/libcyaml/
+// Documentation for libcyaml: https://libyaml.docsforge.com/
+// Tutorial: https://www.wpsoftware.net/andrew/pages/libyaml.html
+
+typedef enum _yaml_state_t {
+  SEEN_NOTHING,
+  SEEN_YAML_KEY,
+  SEEN_VALUE,
+  SEEN_MAPPING,
+  SEEN_NODE_KEY,
+  SEEN_NODE_UUID,
+  SEEN_NODE_LEFT,
+  SEEN_NODE_RIGHT
+} yaml_state_t;
+
+typedef struct _node_state_t {
+  yaml_state_t yaml_state;
+  Node * root_node;
+  Node * current_node;
+  enum context {
+    NONE,
+    LEFT,
+    RIGHT
+  } context;
+} node_state_t;
+
+// TODO: move all context and state into node state struct
+// TODO: Alias "puts" to a macro or something which switches on DEBUG
+// TODO: Refactor all this to a function.
+// https://stackoverflow.com/questions/20628099/parsing-yaml-to-values-with-libyaml-in-c
+
+void
+consume_event(yaml_event_t * event, node_state_t * node_state) {
+  Node * node = NULL;  
+  unsigned char * tk;
+  char yaml_key[100];
+
+  tk = event->data.scalar.value;
+
+  switch (event->type) {
+  case YAML_NO_EVENT:
+    // puts("YAML_NO_EVENT");
+    break;
+  case YAML_STREAM_START_EVENT:
+    // puts("STREAM START");
+    break;
+  case YAML_STREAM_END_EVENT:
+    // puts("STREAM END");
+    break;
+  /* Block delimeters */
+  case YAML_DOCUMENT_START_EVENT:
+    // puts("YAML_DOCUMENT_START_EVENT");
+    break;
+  case YAML_DOCUMENT_END_EVENT:
+    // puts("YAML_DOCUMENT_END_EVENT");
+    break;
+  case YAML_SEQUENCE_START_EVENT:
+    // puts("YAML_SEQUENCE_START_EVENT");
+    break;
+  case YAML_SEQUENCE_END_EVENT:
+    // puts("YAML_SEQUENCE_END_EVENT");
+    break;
+  case YAML_MAPPING_START_EVENT:
+    // puts("YAML_MAPPING_START_EVENT");
+    node_state->yaml_state = SEEN_MAPPING;
+    break;
+  case YAML_MAPPING_END_EVENT:
+    // puts("YAML_MAPPING_END_EVENT");
+    // Need to "pop the stack" here, set the current node *
+    // to its parent.
+    // At the end of all processing, the current node should
+    // once again point to the same node as the root node.
+    node_state->current_node = node_state->current_node->parent;
+    break;
+
+  /* Data */
+  case YAML_ALIAS_EVENT:
+    // puts("YAML_ALIAS_EVENT");
+    break;
+  case YAML_SCALAR_EVENT:
+    // puts("YAML_SCALAR_EVENT");
+
+    if (node_state->yaml_state == SEEN_MAPPING || node_state->yaml_state == SEEN_VALUE) {
+      strcpy(yaml_key, (const char *)tk);
+
+      if (!strcmp((const char *)yaml_key, "key")) {
+        node_state->yaml_state = SEEN_NODE_KEY;
+
+      } else if (!strcmp((const char *)yaml_key, "uuid")) {
+        node_state->yaml_state = SEEN_NODE_UUID;
+
+      } else if (!strcmp((const char *)yaml_key, "left")) {
+        node_state->yaml_state = SEEN_NODE_LEFT;
+        node_state->context = LEFT;
+
+      } else if (!strcmp((const char *)yaml_key, "right")) {
+        node_state->yaml_state = SEEN_NODE_RIGHT;
+        node_state->context = RIGHT;
+      }
+
+      break;
+    } else if (node_state->yaml_state == SEEN_NODE_KEY) {
+      node = node_new(atoi((const char *)tk));
+      if (node_state->root_node == NULL) {
+        node_state->root_node = node;
+        node_state->current_node = node;
+      } else {
+        if (node_state->context == LEFT) {
+          node->parent = node_state->current_node;
+          node_state->current_node->left = node;
+          node_state->current_node = node;
+        } else if (node_state->context == RIGHT) {
+          node->parent = node_state->current_node;
+          node_state->current_node->right = node;
+          node_state->current_node = node;
+        }
+      }
+      node_state->context = NONE;
+      node_state->yaml_state = SEEN_VALUE;
+
+    } else if (node_state->yaml_state == SEEN_NODE_UUID) {
+      strcpy(node_state->current_node->uuid, (const char *)tk);
+      node_state->yaml_state = SEEN_VALUE;
+
+    } else if (node_state->yaml_state == SEEN_NODE_LEFT) {
+      node_state->yaml_state = SEEN_VALUE;
+
+    } else if (node_state->yaml_state == SEEN_NODE_RIGHT) {
+      node_state->yaml_state = SEEN_VALUE;
+
+    } else {
+      break;
+    }
+  }
+}
+
+Node *
+parsing_loop(yaml_parser_t * parser, yaml_event_t * event, node_state_t * node_state) {
+
+  do {
+    if (!yaml_parser_parse(parser, event)) {
+      printf("Parser error %d\n", parser->error);
+      exit(EXIT_FAILURE);
+    }
+
+    consume_event(event, node_state);
+
+    if (event->type != YAML_STREAM_END_EVENT) {
+      yaml_event_delete(event);
+    }
+  } while (event->type != YAML_STREAM_END_EVENT);
+
+  return node_state->root_node;
+}
 
 Node * load_tree(FILE * yaml_file) {
   Node * root_node = NULL;
 
+  yaml_parser_t parser;
+  yaml_event_t event;
+  node_state_t node_state;
+  memset(&node_state, 0, sizeof(node_state));
+  node_state.yaml_state = SEEN_NOTHING;
+
+  if (!yaml_parser_initialize(&parser)) {
+    fputs("Failed to initialize parser!\n", stderr);
+  }
+
+  if (yaml_file == NULL) {
+    fputs("Failed to open file!\n", stderr);
+  }
+
+  yaml_parser_set_input_file(&parser, yaml_file);
+  root_node = parsing_loop(&parser, &event, &node_state);
+
+  yaml_event_delete(&event);
+  yaml_parser_delete(&parser);
   return root_node;
 }
 
@@ -19,16 +200,10 @@ Node * display_yaml(void) {
 
 int main(void) {
   Node * node = display_yaml();
-  // printf("node root location: %p\n", node);
-  // printf("node key: %d\n", node->key);
-  // printf("node left location: %p\n", node->left);
-  // printf("node right location: %p\n", node->right);
-  // printf("node left key: %d\n", node->left->key);
-  // printf("node right key: %d\n", node->right->key);
-  // Collector * collector = collector_new(100);
-  // node_collect(node, collector);
-  // collector_printf(collector);
-  // collector_destroy(collector);
+  Collector * collector = collector_new(100);
+  node_collect(node, collector);
+  collector_printf(collector);
+  collector_destroy(collector);
   return 0;
 }
 #endif // STANDALONE

--- a/c/test/test_yaml.cpp
+++ b/c/test/test_yaml.cpp
@@ -15,27 +15,144 @@ class YamlTest : public CppUnit::TestCase {
   public:
   YamlTest( std::string name ) : CppUnit::TestCase( name ) {}
 
-  void test_dummy() {
+  void test_load_tree() {
     describe_test(INDENT0, "Dummy yaml test");
     
     Spec spec;
 
-    spec.it("does nothing", DO_SPEC_HANDLE {
+    spec.it("loads a single node BST", DO_SPEC_HANDLE {
+      FILE *yaml_file = fopen("../../fixtures/tree1.yml", "r");
+      Node * node = load_tree(yaml_file);
+      fclose(yaml_file);
+      return (
+        node_key(node) == 11 &&
+        node_size(node) == 1 &&
+        node_height(node) == 0 &&
+        node_is_bst(node) == true
+        );
+    });
+
+    spec.it("loads a two node BST", DO_SPEC_HANDLE {
+      FILE *yaml_file = fopen("../../fixtures/tree2.yml", "r");
+      Node * node = load_tree(yaml_file);
+      fclose(yaml_file);
+      return (
+        node_key(node) == 11 &&
+        node_key(node->left) == 7 &&
+        node_size(node) == 2 &&
+        node_height(node) == 1 &&
+        node_is_bst(node) == true
+      );
+    });
+
+    spec.it("loads a three node BST", DO_SPEC_HANDLE {
+      FILE *yaml_file = fopen("../../fixtures/tree3.yml", "r");
+      Node * node = load_tree(yaml_file);
+      fclose(yaml_file);
+      return (
+        node_key(node) == 11 &&
+        node_key(node->left) == 7 &&
+        node_size(node) == 3 &&
+        node_height(node) == 1 &&
+        node_is_bst(node) == true
+      );
+    });
+
+    spec.it("loads a four node BST", DO_SPEC_HANDLE {
+      FILE *yaml_file = fopen("../../fixtures/tree4.yml", "r");
+      Node * node = load_tree(yaml_file);
+      fclose(yaml_file);
+      return (
+        node_key(node) == 11 &&
+        node_key(node->left) == 7 && 
+        node_size(node) == 4 && 
+        node_height(node) == 2 &&
+        node_is_bst(node) == true
+      );
+    });
+
+    spec.it("loads a five node BST", DO_SPEC_HANDLE {
+      FILE *yaml_file = fopen("../../fixtures/tree5.yml", "r");
+      Node * node = load_tree(yaml_file);
+      fclose(yaml_file);
+      return (
+        node_key(node) == 11 &&
+        node_key(node->left) == 7 &&
+        node_size(node) == 5 &&
+        node_height(node) == 2 &&
+        node_is_bst(node) == true
+      );
+    });
+
+    spec.it("loads a six node BST", DO_SPEC_HANDLE {
+      FILE *yaml_file = fopen("../../fixtures/tree6.yml", "r");
+      Node * node = load_tree(yaml_file);
+      fclose(yaml_file);
+      return (
+        node_key(node) == 11 &&
+        node_key(node->left) == 7 &&
+        node_size(node) == 6 &&
+        node_height(node) == 3 &&
+        node_is_bst(node) == true
+      );
+    });
+
+    spec.it("loads a seven node BST", DO_SPEC_HANDLE {
+      FILE *yaml_file = fopen("../../fixtures/tree7.yml", "r");
+      Node * node = load_tree(yaml_file);
+      fclose(yaml_file);
+      return (
+        node_key(node) == 11 &&
+        node_key(node->left) == 7 &&
+        node_size(node) == 7 &&
+        node_height(node) == 3 &&
+        node_is_bst(node) == true
+      );
+    });
+
+    spec.it("loads an eight node BST", DO_SPEC_HANDLE {
+      FILE *yaml_file = fopen("../../fixtures/tree8.yml", "r");
+      Node * node = load_tree(yaml_file);
+      fclose(yaml_file);
+      return (
+        node_key(node) == 11 &&
+        node_key(node->left) == 7 &&
+        node_size(node) == 8 &&
+        node_height(node) == 3 &&
+        node_is_bst(node) == true
+      );
+    });
+
+    spec.it("loads a nine node BST", DO_SPEC_HANDLE {
+      FILE *yaml_file = fopen("../../fixtures/tree9.yml", "r");
+      Node * node = load_tree(yaml_file);
+      fclose(yaml_file);
+      return (
+        node_key(node) == 11 &&
+        node_key(node->left) == 7 &&
+        node_size(node) == 9 &&
+        node_height(node) == 3 &&
+        node_is_bst(node) == true
+      );
+    });
+
+    spec.it("loads a ten node BST", DO_SPEC_HANDLE {
       FILE *yaml_file = fopen("../../fixtures/tree10.yml", "r");
       Node * node = load_tree(yaml_file);
       fclose(yaml_file);
-      return true;
+      return (
+        node_key(node) == 11 &&
+        node_key(node->left) == 7 &&
+        node_size(node) == 10 &&
+        node_height(node) == 4 &&
+        node_is_bst(node) == true
+      );
     });
-
-
   }
 
   void run_tests(void) {
-    //setup();
-    test_dummy();
-    //teardown();
+    test_load_tree();
   }
-
 };
 
 void


### PR DESCRIPTION
The event stream API for libyaml was chosen to implement
a binary search tree configuration loader. Since c doesn't
have any native libraries for working with associative arrays,
a purpose-built struct is defined and passed into the event
loop to keep track of state.

As event stream is linear, the event processor must keep
track of the relative position in the tree. This is accomplished
with a pointer to the currently processing node (current_node),
on an implicit stack. Push and pop are handled via pointer
swaps with the appropriate child and its parent. The root_node
pointer is a convenience, and is not strictly necessary.

A rudimentary test suite is implemented which confirms the
size, height, root node key, and validity of the processed
tree.