### PR TITLE
BST-230 wire yaml processing to Tree

### DIFF
--- a/c/include/is_yaml.h
+++ b/c/include/is_yaml.h
@@ -10,7 +10,7 @@ extern "C" {
 // TODO: return Tree
 Node * load_tree(FILE * yaml_file);
 
-Node * from_yaml(char * filename);
+Node * from_yaml_file(char * filename);
 
 #ifdef __cplusplus
 }

--- a/c/include/tree.h
+++ b/c/include/tree.h
@@ -11,6 +11,8 @@ typedef struct _tree Tree;
 
 Tree * tree_new          (void);
 
+Tree * tree_from_yaml    (const char * filename);
+
 void   tree_delete       (Tree * t);
 
 Node * tree_delete_node  (Tree * t,

--- a/c/src/tree.c
+++ b/c/src/tree.c
@@ -3,6 +3,7 @@
 #include <stdlib.h>
 
 #include <tree.h>
+#include <is_yaml.h>
 #include <collector.h>
 #include "tree_private.h"
 #include "node_private.h" // needed for delete implementation, bummer
@@ -194,4 +195,11 @@ int
 tree_size(Tree * t) {
   if (t->root == NULL) return 0;
   return node_size(t->root);
+}
+
+Tree *
+tree_from_yaml(char * filename) {
+  Tree * tree = tree_new();
+  tree->root = from_yaml_file(filename);
+  return tree;
 }

--- a/c/src/yaml.c
+++ b/c/src/yaml.c
@@ -190,6 +190,14 @@ Node * load_tree(FILE * yaml_file) {
   return root_node;
 }
 
+Node *
+from_yaml_file(const char * filename) {
+  FILE * yaml_file = fopen(filename, "r");
+  Node * node = load_tree(yaml_file);
+  fclose(yaml_file);
+  return node;
+}
+
 #ifdef STANDALONE
 Node * display_yaml(void) {
   FILE *yaml_file = fopen("../../fixtures/tree10.yml", "r");

--- a/c/test/Makefile.am
+++ b/c/test/Makefile.am
@@ -3,7 +3,7 @@ AM_CPPFLAGS = -I../include # -I. $(shell cppunit-config --cflags)
 
 # AM_LDFLAGS = $(shell cppunit-config --libs)
 # Not used with clang at the moment, save it in case
-AM_LDFLAGS = -L/usr/local/Cellar/boost/1.62.0/lib/ # $(shell cppunit-config --libs) 
+# AM_LDFLAGS = -L/usr/local/Cellar/boost/1.62.0/lib/ # $(shell cppunit-config --libs)
 LDADD = ../src/libbst.a
 
 %.o: %.cpp
@@ -15,5 +15,3 @@ node_SOURCES = test_node.cpp testutils.cpp
 tree_SOURCES = test_tree.cpp testutils.cpp
 collector_SOURCES = test_collector.cpp testutils.cpp
 yaml_SOURCES = test_yaml.cpp testutils.cpp
-
-

--- a/c/test/test_tree.cpp
+++ b/c/test/test_tree.cpp
@@ -765,6 +765,36 @@ public:
     tree_delete(t);
   }
 
+  void test_tree_from_yaml(void) {
+    describe_test(INDENT0, "From test_tree_from_yaml in TreeTest");
+    Spec spec;
+    Tree * tree;
+
+    tree = tree_from_yaml("../../fixtures/tree1.yml");
+    spec.it("load single node tree", DO_SPEC_HANDLE {
+      Node * node = tree->root;
+      return (
+        node_key(node) == 11 &&
+        node_size(node) == 1 &&
+        node_height(node) == 0 &&
+        node_is_bst(node) == true
+        );
+    });
+    tree_delete(tree);
+
+    tree = tree_from_yaml("../../fixtures/tree10.yml");
+    spec.it("load ten node tree", DO_SPEC_HANDLE {
+      Node * node = tree->root;
+      return (
+        node_key(node) == 11 &&
+        node_size(node) == 10 &&
+        node_height(node) == 4 &&
+        node_is_bst(node) == true
+        );
+    });
+    tree_delete(tree);
+  }
+
   void run_tests(void) {
     test_tree_new_and_delete();
     test_tree_insert();
@@ -783,6 +813,7 @@ public:
     test_tree_transplant();
     test_tree_list_keys();
     test_tree_delete_node();
+    test_tree_from_yaml();
   }
 };
 

--- a/c/test/test_yaml.cpp
+++ b/c/test/test_yaml.cpp
@@ -5,7 +5,7 @@
 
 #include <node.h>
 #include <collector.h>
-#include <yaml.h>
+#include <is_yaml.h>
 #include "../src/node_private.h"
 
 using std::string;
@@ -16,8 +16,7 @@ class YamlTest : public CppUnit::TestCase {
   YamlTest( std::string name ) : CppUnit::TestCase( name ) {}
 
   void test_load_tree() {
-    describe_test(INDENT0, "Dummy yaml test");
-    
+    describe_test(INDENT0, "From test_load_tree in YamlTest");
     Spec spec;
 
     spec.it("loads a single node BST", DO_SPEC_HANDLE {
@@ -64,8 +63,8 @@ class YamlTest : public CppUnit::TestCase {
       fclose(yaml_file);
       return (
         node_key(node) == 11 &&
-        node_key(node->left) == 7 && 
-        node_size(node) == 4 && 
+        node_key(node->left) == 7 &&
+        node_size(node) == 4 &&
         node_height(node) == 2 &&
         node_is_bst(node) == true
       );


### PR DESCRIPTION
The existing implementation focused on the yaml and node
implementations, without providing an API for loaing from
the actual Tree API, which is what would be needed in a
production system. These changes provide that API implementation.

Minor Makefile.am adjustment and white space fixes for cleanup.
Everything now compiles and links with no warnings or errors.