### PR TITLE
BST-240 AVL double rotations

### DIFF
--- a/ruby/lib/avl_node.rb
+++ b/ruby/lib/avl_node.rb
@@ -10,9 +10,9 @@ class AvlNode < Node
     @balance_factor = 0
   end
 
-  def insert(node, balance: true)
+  def insert(node)
     super
-    balance_node if balance
+    balance_node
   end
 
   # rubocop:disable  Metrics/MethodLength
@@ -22,14 +22,18 @@ class AvlNode < Node
     if @balance_factor < -1
       if left.balance_factor == 1
         d_rot_right
+        # rotate_left_right
       else
         right_rot
+        # rotate_right
       end
     elsif @balance_factor > 1
       if right.balance_factor == -1
         d_rot_left
+        # rotate_right_left
       else
         left_rot
+        # rotate_left
       end
     end
   end
@@ -59,6 +63,7 @@ class AvlNode < Node
   #
   # rubocop:disable Metrics/AbcSize
   # rubocop:disable Metrics/MethodLength
+  # return [AvlNode] the new subtree root
   def rotate_right
     parent = self.parent       # might be nil if actual root of whole tree
 
@@ -98,6 +103,8 @@ class AvlNode < Node
   #            n43
   # rubocop:disable Metrics/AbcSize
   # rubocop:disable Metrics/MethodLength
+  #
+  # return [AvlNode] the new subtree root
   def rotate_left
     parent = self.parent # might be nil if actual root of whole tree
 
@@ -128,11 +135,33 @@ class AvlNode < Node
   # rubocop:enable Metrics/MethodLength
   # rubocop:enable Metrics/AbcSize
 
+  # Here is the general case, which won't occur when balancing on insertion,
+  # but could occur as a result some operation such as a deletion of a child
+  # node for node 29.
+  #
+  #      17                 17                11
+  #     / \                /  \              /   \
+  #    7   29             11  29           7      17
+  #   / \      ===>      /  \      ===>   / \    /  \
+  #  5   11             7   13           5   9  13  29
+  #     / \            / \
+  #    9   13         5   9
+  #
+  # return [AvlNode] the new subtree root, left on the stack from the `rotate_right` invocation.
   def rotate_left_right
     left.rotate_left
     rotate_right
   end
 
+  #       7                   7                   13
+  #     /   \               /  \                 /   \
+  #    5    19             5   13              7     19
+  #        /  \   ===>         / \     ===>   / \    / \
+  #       13  43            11  19           5  11  17 43
+  #      /  \                  /  \
+  #     11   17               17  43
+  #
+  # return [AvlNode] the new subtree root, left on the stack from the `rotate_left` invocation.
   def rotate_right_left
     right.rotate_right
     rotate_left

--- a/ruby/lib/node.rb
+++ b/ruby/lib/node.rb
@@ -45,7 +45,7 @@ class Node
   # a value is easier before executing insertion.
   #
   # TODO: add a callback (monad?) for duplicate key handling
-  def insert(node, _options = {})
+  def insert(node)
     node < self ? insert_left(node) : insert_right(node)
   end
 

--- a/ruby/spec/avl_node_spec.rb
+++ b/ruby/spec/avl_node_spec.rb
@@ -4,12 +4,6 @@ require 'spec_helper'
 
 require 'shared_examples/insert'
 
-class AvlNode < Node
-  def nb_insert(node)
-    insert(node, balance: false)
-  end
-end
-
 RSpec.describe AvlNode do
   it_inserts_like 'insertion'
 
@@ -18,6 +12,7 @@ RSpec.describe AvlNode do
   let(:n2) { described_class.new 2 }
   let(:n5) { described_class.new 5 }
   let(:n7) { described_class.new 7 }
+  let(:n9) { described_class.new 9 }
   let(:n11) { described_class.new 11 }
   let(:n13) { described_class.new 13 }
   let(:n17) { described_class.new 17 }
@@ -56,6 +51,7 @@ RSpec.describe AvlNode do
       it 'calls right_rot' do
         root.insert n5
         expect(root).to receive(:right_rot)
+        # expect(root).to receive(:rotate_right)
         root.insert n2
       end
 
@@ -89,8 +85,8 @@ RSpec.describe AvlNode do
     #     n23
     context 'right chain with 3 nodes' do
       before do
-        n13.nb_insert n19
-        n13.nb_insert n23
+        n13.insert n19
+        n13.insert n23
         n13.rotate_left
       end
 
@@ -350,6 +346,7 @@ RSpec.describe AvlNode do
       end
     end
 
+    # TODO: document or delete
     it 'rotates clockwise' do
       n17.insert n23
       n17.insert n11
@@ -362,10 +359,12 @@ RSpec.describe AvlNode do
       expect(n11.size).to eq 5
     end
 
+    # TODO: document that this is an isolated test for a "knee" situation
     context 'left knee' do
       before do
         n17.insert n7
         n17.insert n11
+        # NOTE: n7 is the root of the left subtree
         n7.rotate_left
       end
 
@@ -395,51 +394,309 @@ RSpec.describe AvlNode do
   end
 
   describe '#rotate_left_right' do
-    # TODO: draw some ascii art for this case
-    context 'left knee' do
+    #      n17             n11
+    #     /               /   \
+    #    n7     ====>   n7    n17
+    #      \
+    #      n11
+    context 'for simple left knee' do
       before do
         n17.insert n7
         n17.insert n11
         n17.rotate_left_right
       end
 
-      # TODO: split these into separate test cases
-      it 'moves the root node to right child' do
+      it 'remains the same size' do
+        expect(n11.size).to be 3
+      end
+
+      it 'has the correct pre-ordering' do
         expected = [11, 7, 17]
         actual = n11.preorder_collect
         expect(actual).to eq expected
-        expect(n7.parent).to eq n11
-        expect(n11.left).to eq n7
+      end
+
+      it "moves the old root to the new root's right child" do
         expect(n17.parent).to eq n11
         expect(n11.right).to eq n17
+      end
+
+      it "rewrites new root's left child" do
+        expect(n7.parent).to eq n11
+        expect(n11.left).to eq n7
+      end
+
+      it 'correctly computes new balance factors' do
+        expect(n11.balance_factor).to be 0
+        expect(n17.balance_factor).to be 0
+        expect(n7.balance_factor).to be 0
+      end
+    end
+
+    #      17                 17                11
+    #     / \                /  \              /   \
+    #    7   29             11  29           7      17
+    #   / \      ===>      /  \      ===>   / \    /  \
+    #  5   11             7   13           5   9  13  29
+    #     / \            / \
+    #    9   13         5   9
+    context 'left knee with left child' do
+      before do
+        n17.insert n7
+        n17.insert n5
+        n17.insert n11
+        n17.insert n9
+        n17.insert n13
+        n17.insert n29
+        n17.rotate_left_right
+      end
+
+      it 'remains the same size' do
+        expect(n11.size).to be 7
+      end
+
+      it 'returns the correct preordering' do
+        expected = [11, 7, 5, 9, 17, 13, 29]
+        actual = n11.preorder_collect
+        expect(actual).to eq expected
+      end
+
+      it 'keeps the initial pivot left node in place' do
+        expect(n11.left).to be n7
+        expect(n7.parent).to be n11
+      end
+
+      it 'correctly reassigns the swinger node' do
+        expect(n17.left).to be n13
+        expect(n13.parent).to be n17
+      end
+
+      it 'moves the old root node to the new root node\'s right child' do
+        expect(n11.right).to be n17
+      end
+
+      it 'correctly recomputes balance factors' do
+        expect(n11.balance_factor).to be 0
+        expect(n17.balance_factor).to be 0
+      end
+
+      it 'correctly reassigns parent nodes' do
+        expect(n17.parent).to be n11
+        expect(n11.parent).to be nil
+      end
+    end
+
+    context 'check root parent reassignment for subtree' do
+      before do
+        n17.insert n7
+        n17.insert n11
+      end
+
+      #     1              1
+      #      \              \
+      #      n17             n11
+      #     /               /   \
+      #    n7     ====>   n7    n17
+      #      \
+      #      n11
+      it 'reassigns right child subtree' do
+        n1.right = n17
+        n17.parent = n1
+        n17.rotate_left_right
+
+        expect(n11.parent).to be n1
+        expect(n17.parent).to be n11
+      end
+
+      #         43              43
+      #        /               /
+      #      n17             n11
+      #     /               /   \
+      #    n7     ====>   n7    n17
+      #      \
+      #      n11
+      it 'ressigns left child subtree' do
+        n17.parent = n43
+        n43.left = n17
+        n17.rotate_left_right
+
+        expect(n43.left).to be n11
+        expect(n11.parent).to be n43
+      end
+
+      #      nil             nil
+      #       |               |
+      #      n17             n11
+      #     /               /   \
+      #    n7     ====>   n7    n17
+      #      \
+      #      n11
+      it 'nil parent remains nil' do
+        n17.rotate_left_right
+
+        expect(n11.parent).to be nil
+        expect(n17.parent).to be n11
       end
     end
   end
 
   describe '#rotate_right_left' do
-    # TODO: add some ascii art to this
-    context 'right knee' do
-      it 'moves root node to left child' do
-        root.insert n29
-        root.insert n23
-        root.rotate_right_left
+    #
+    #     n17               n23
+    #       \              /   \
+    #       n29   ===>   n17   n29
+    #      /
+    #     n23
+    context 'for simple right knee' do
+      before do
+        n17.insert n29
+        n17.insert n23
+        n17.rotate_right_left
+      end
 
-        # TODO: split these into separate test cases
+      it 'subtree remains the same size' do
+        expect(n23.size).to be 3
+      end
+
+      it 'has correct preordering' do
         expected = [23, 17, 29]
         actual = n23.preorder_collect
         expect(actual).to eq expected
-        expect(n23.left).to eq root
+      end
+
+      it 'moves root node to left child' do
+        expect(n23.left).to eq n17
+        expect(n17.parent).to eq n23
+      end
+
+      it 'rewrites the the new subtree root\'s right child' do
         expect(n23.right).to eq n29
         expect(n29.parent).to eq n23
-        expect(root.parent).to eq n23
+      end
+
+      it 'recomputes balance factors' do
+        expect(n17.balance_factor).to be 0
+        expect(n23.balance_factor).to be 0
+        expect(n29.balance_factor).to be 0
+      end
+    end
+
+    #       7                   7                   13
+    #     /   \               /  \                 /   \
+    #    5    19             5   13              7     19
+    #        /  \   ===>         / \     ===>   / \    / \
+    #       13  43            11   19          5  11  17 43
+    #      /  \                   /  \
+    #     11   17                17  43
+    #
+    #
+    context 'right knee with right child' do
+      before do
+        n7.insert n5
+        n7.insert n19
+        n7.insert n13
+        n7.insert n11
+        n7.insert n17
+        n7.insert n43
+        n7.rotate_right_left
+      end
+
+      it 'remains the same size' do
+        expect(n13.size).to be 7
+      end
+
+      it 'has correct preordering' do
+        expected = [13, 7, 5, 11, 19, 17, 43]
+        actual = n13.preorder_collect
+        expect(actual).to eq expected
+      end
+
+      it 'keeps the initial subtree right node in place' do
+        expect(n19.right).to be n43
+        expect(n43.parent).to be n19
+      end
+
+      it 'correctly reassigns the right rotation swinger node' do
+        expect(n17.parent).to be n19
+        expect(n19.left).to be n17
+      end
+
+      it 'correctly reassigns the left rotation swinger node' do
+        expect(n11.parent).to be n7
+        expect(n7.right).to be n11
+      end
+
+      it 'moves the old root node to the new root node\'s left child' do
+        expect(n7.parent).to be n13
+        expect(n13.left).to be n7
+      end
+
+      it 'correctly updates balance factors' do
+        expect(n7.balance_factor).to be 0
+        expect(n13.balance_factor).to be 0
+      end
+
+      it 'reassigns parents' do
+        expect(n13.parent).to be nil
+        expect(n7.parent).to be n13
+      end
+    end
+
+    context 'check root parent reassignment for subtree' do
+      before do
+        n17.insert n29
+        n17.insert n23
+      end
+
+      #    n1                n1
+      #     \                 \
+      #     n17               n23
+      #       \              /   \
+      #       n29   ===>   n17   n29
+      #      /
+      #     n23
+      it 'reassigns right child subtree' do
+        n17.parent = n1
+        n1.right = n17
+        n17.rotate_right_left
+
+        expect(n1.right).to be n23
+        expect(n23.parent).to be n1
+      end
+
+      #       n43               n43
+      #       /                 /
+      #     n17               n23
+      #       \              /   \
+      #       n29   ===>   n17   n29
+      #      /
+      #     n23
+      it 'reassigns left child subtree' do
+        n43.left = n17
+        n17.parent = n43
+        n17.rotate_right_left
+
+        expect(n43.left).to be n23
+        expect(n23.parent).to be n43
+      end
+
+      #     nil               nil
+      #      |                 |
+      #     n17               n23
+      #       \              /   \
+      #       n29   ===>   n17   n29
+      #      /
+      #     n23
+      it 'nil parent remains nil' do
+        n17.rotate_right_left
+
+        expect(n23.parent).to be nil
+        expect(n17.parent).to be n23
       end
     end
   end
 
   describe '#balanced?' do
-    let(:n11) { described_class.new 11 }
-    let(:n43) { described_class.new 43 }
-
     it 'is true for node with 0 children' do
       expect(root.balanced?).to be true
       expect(root.weight).to eq 0
@@ -517,14 +774,31 @@ RSpec.describe AvlNode do
     end
 
     it 'is true for right and left chain at root' do
-      root.insert n7
-      root.insert n19
-      root.insert n5
-      root.insert n29
-      root.insert n2
-      root.insert n43
-      expect(root.balanced?).to be true
-      expect(root.weight).to eq(0)
+      expect(root.key).to be 17
+      expect(n17.left).to be nil
+      expect(n17.right).to be nil
+
+      n17.insert n7
+      expect(n17.left_height).to be 1
+      n17.insert n19
+      expect(n17.balance_factor).to eq(0)
+
+      n17.insert n5
+      expect(n17.left_height).to be 2
+      n17.insert n29
+      expect(n17.balance_factor).to eq(0)
+
+      n17.insert n2
+      expect(n5.left).to be n2
+      expect(n17.left_height).to be 3
+
+      n17.insert n43
+      expect(n17.balance_factor).to eq(0)
+
+      expect(n17.balanced?).to be true
+      expect(n17.right_height).to be 3
+      expect(n17.left_height).to be 3
+      expect(n17.balance_factor).to eq(0)
     end
   end
 

--- a/ruby/spec/spec_helper.rb
+++ b/ruby/spec/spec_helper.rb
@@ -7,6 +7,7 @@ SimpleCov.start do
 end
 
 require 'ap'
+require 'debug'
 
 Dir[File.join(File.dirname(__FILE__), '..', 'lib', '**.rb')].sort.each do |f|
   require f


### PR DESCRIPTION
Double rotations are the same as single rotations applied
to appropriate child nodes, which are determined by the
local balance factor of the child.

This commit doesn't hook up the automatic balancing on
insertion. That will be an upcoming commit.