### PR TITLE
BST-242 add yard documentation processing

### DIFF
--- a/ruby/.gitignore
+++ b/ruby/.gitignore
@@ -2,3 +2,5 @@
 tmp/
 .rspec_status
 coverage/
+.yardoc
+doc/

--- a/ruby/Gemfile
+++ b/ruby/Gemfile
@@ -16,3 +16,5 @@ gem 'rubocop-rspec'
 
 gem 'sentry-ruby'
 gem 'simplecov', require: false, group: :test
+
+gem 'yard'

--- a/ruby/Gemfile.lock
+++ b/ruby/Gemfile.lock
@@ -97,6 +97,9 @@ GEM
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.3)
     unicode-display_width (2.1.0)
+    yard (0.9.26)
+    yard-rspec (0.1)
+      yard
 
 PLATFORMS
   ruby
@@ -111,6 +114,8 @@ DEPENDENCIES
   rubocop-rspec
   sentry-ruby
   simplecov
+  yard
+  yard-rspec
 
 RUBY VERSION
    ruby 3.0.2p107

--- a/ruby/lib/avl_node.rb
+++ b/ruby/lib/avl_node.rb
@@ -50,7 +50,7 @@ class AvlNode < Node
   # I believe this and the rotate_left methods are probably correct.
   # The challenge is that after the rotation, there may be a new subtree
   # root, which may be the root of the entire tree as well. This case is
-  # not covered by any of the literature, and frankly is there more
+  # not covered by any of the literature, and frankly is the more
   # interesting aspect of the implementation from an engineering perspective.
   #
   #             17                   11
@@ -94,6 +94,9 @@ class AvlNode < Node
   # rubocop:enable Metrics/MethodLength
   # rubocop:enable Metrics/AbcSize
 
+  # When the balance factor is greater than 1, the tree is out of
+  # balance to the right and needs to rotate left.
+  #
   #    13                   19
   #   /   \      ===>      /  \
   #  11   19             13    23
@@ -153,6 +156,10 @@ class AvlNode < Node
     rotate_right
   end
 
+  # As with `rotate_left_right`, a deletion may induce an otherwise balanced tree
+  # to become unbalanced. An overweight right hand branch with a left child requires
+  # rotating right first, then rotating left.
+  #
   #       7                   7                   13
   #     /   \               /  \                 /   \
   #    5    19             5   13              7     19
@@ -189,6 +196,8 @@ class AvlNode < Node
 
   # TODO: see if this can punt to the parent Node class.
   # Move the relevant tests to shared examples.
+  #
+  # @return [Integer] size of the tree rooted at the Node instance.
   def size
     size = 0
     post_order_traverse { size += 1 }

--- a/ruby/lib/node.rb
+++ b/ruby/lib/node.rb
@@ -116,19 +116,39 @@ class Node
   end
   # rubocop:enable Naming/MethodParameterName
 
-  # Definition. The size of a tree is its number of nodes. The depth of a node in a tree
+  # Definitions: The size of a tree is its number of nodes. The depth of a node in a tree
   # is the number of links on the path from it to the root. The height of a tree is the
   # maximum depth among its nodes. p. 226 Sedgewick and Wayne 4th edition.
   #
-  # From MIT Opencourseware: https://www.youtube.com/watch?v=76dhtgZt38A&list=PLUl4u3cNGP63EdVPNLG3ToM6LaEUuStEY&index=10
-  # the _height_ of a node is the number of edges in the longest downward path from the node.
+  # From MIT Opencourseware:
+  # {https://www.youtube.com/watch?v=76dhtgZt38A&list=PLUl4u3cNGP63EdVPNLG3ToM6LaEUuStEY&index=10
+  # the _height_ of a node is the number of edges in the longest downward path from the node}.
   # This is the same as the maximum depth of children in the nodes subtree. Notably, all leaves
   # have height 0.
   #
-  # Notably, this article on geeksforgeeks is wrong:
-  # https://www.geeksforgeeks.org/count-balanced-binary-trees-height-h/
-  # defining the height at the number of links + 1, that is, they are
-  # off by 1. This does not give me assurance for the gfg site.
+  # Notably, this article on geeksforgeeks is wrong,
+  # {https://www.geeksforgeeks.org/count-balanced-binary-trees-height-h/
+  # defining the height at the number of links + 1}, that is, they are
+  # off by 1 with respect to the MIT-provided definition. This does not
+  # give me assurance for the gfg site.
+  #
+  # ==Examples
+  #
+  #  Height 0:    17
+  #
+  #  height 1:    17
+  #              /
+  #  Height 0:  5
+  #
+  #  Height 2:    17
+  #                 \
+  #  Height 1:       23
+  #                    \
+  #  Height 0:          29
+  #
+  #
+  # @return [Integer] the number of edges between the Node instance and longest path
+  #  to a child leaf node.
   def height
     # use for demonstrating complexity, etc.
     yield(self) if block_given?
@@ -139,10 +159,26 @@ class Node
     self.class.max(left&.height || -1, right&.height || -1) + 1
   end
 
-  # https://www.youtube.co/watch?v=76dhtgZt38A&list=PLUl4u3cNGP63EdVPNLG3ToM6LaEUuStEY&index=10
-  # Depth from Eric Demaine, MIT Opencourseware, is the number of edges from the node up
+  # {https://www.youtube.co/watch?v=76dhtgZt38A&list=PLUl4u3cNGP63EdVPNLG3ToM6LaEUuStEY&index=10
+  # Depth from Eric Demaine, MIT Opencourseware}, is the number of edges from the node up
   # to the root. Depth measures from the root down. Note that the depth of tree is not defined,
   # only depth of node is defined.
+  #
+  # ==Examples
+  #
+  #  Depth 0:    17
+  #
+  #  Depth 0:    17
+  #             /
+  #  Depth 1:  5
+  #
+  #  Depth 0:    17
+  #                \
+  #  Depth 1:      23
+  #                  \
+  #  Depth 2:        29
+  #
+  # @return [Integer] number of edges from node instance to root
   def depth
     depth = 0
     parent = self.parent
@@ -192,6 +228,7 @@ class Node
     key < @key ? left&.find_with_parent(key, self) : right&.find_with_parent(key, self)
   end
 
+  # @return [Node] the node containing the desired key.
   # rubocop:disable Metrics/CyclomaticComplexity
   def find(key, &block)
     yield(self) if block_given?
@@ -269,9 +306,13 @@ class Node
     end
   end
 
+  # This is a common coding challenge problem, where the
+  # implementation requires an O(n) derivation when given
+  # two arrays. Ruby has the set intersection operator built-in.
   def least_common_ancestor(key1, key2)
     p1 = path_to_node(key1, [])
     p2 = path_to_node(key2, [])
+    # TODO: dig into how Ruby set intersection works.
     (p1 & p2).last
   end
   alias lca least_common_ancestor

--- a/ruby/lib/tree.rb
+++ b/ruby/lib/tree.rb
@@ -1,9 +1,19 @@
 # frozen_string_literal: true
 
+# Tree provides a container and interface for the recursive tree
+# data structure. Importantly, Tree keeps track of the current
+# root of the data structure, which can change on deletions, or
+# balancing, or possibly other operations TBD.
+#
+# Many if not most of the Tree methods are pass-through, that is,
+# the methods send a message to the corresponding method of the
+# current root.
+#
 # rubocop:disable Metrics/ClassLength
 class Tree
   attr_reader :root, :size
 
+  # Specifying NODE_CLASS allows subclassing both Tree and Node.
   NODE_CLASS = Node
 
   def preorder_walk(&block)
@@ -164,7 +174,7 @@ class Tree
 
   # From MIT Opencourseware, https://www.youtube.com/watch?v=76dhtgZt38A&list=PLUl4u3cNGP63EdVPNLG3ToM6LaEUuStEY&index=10,
   # the height of a tree is the height of the root. Note: depth of tree is not defined,
-  # only depth of nodes.
+  # only depth of nodes. See {Node#depth}
   def height
     root.nil? ? 0 : root.height
   end


### PR DESCRIPTION
Adding a documentation processor is overdue. Ruby `yard`
processor was chosen as it allows RDoc for backward
compatibility, but otherwise resembles most other documentation
processors syntactically. In the past I've been add a lot of
the documentation and implementation notes to a LaTeX file,
which is inefficient from the standpoint of looking things up.
Independent documentation is convenient for spanning multiple
source code implementations, at least for high level concepts.