### PR TITLE
BST-256 print a single node to console

### DIFF
--- a/c++/include/node.h
+++ b/c++/include/node.h
@@ -17,11 +17,11 @@ class Node {
     void get_right(std::vector<int> & keys);
 
   public:
-    Node(int _key) : key(_key), left(nullptr), right(nullptr), parent(nullptr) {}
+    Node(int _key) : key(_key), uuid("fixme"), left(nullptr), right(nullptr), parent(nullptr) {}
 
-    // void post_order_traverse(std::function<void (const Node&)> callback);
-    void post_order_traverse(std::function<void (void)> callback);
+    // void pre_order_traverse(std::function<void (const Node&)> callback);
     void in_order_traverse(std::function<void (void)> callback);
+    void post_order_traverse(std::function<void (void)> callback);
 
     void insert(Node * node);
     void insert_left(Node * node);
@@ -41,8 +41,10 @@ class Node {
     bool is_bst(void);
     int size(void);
     int height(void);
+    void print_to_console(void);
 
     int key;
+    std::string uuid;
     Node * left;
     Node * right;
     Node * parent;

--- a/c++/src/node.cpp
+++ b/c++/src/node.cpp
@@ -201,3 +201,13 @@ get_node(void) {
 
   return std::string("node");
 }
+
+void
+Node::print_to_console() {
+  std::cout << "key: " << this->key << "\n";
+  std::cout << "uuid: " << this->uuid << "\n";
+  std::cout << "left: " << this->left << "\n";
+  std::cout << "right: " << this->right << "\n";
+  std::cout << "parent: " << this->parent << "\n";
+
+}

--- a/c++/test/node_test.cpp
+++ b/c++/test/node_test.cpp
@@ -367,6 +367,13 @@ public:
     });
   }
 
+  void test_print_to_console() {
+    describe_test(INDENT0, "From test_print_to_console in NodeTest");
+
+    Node root(17);
+    root.print_to_console();
+  }
+
   void runTest() {
     test_instantiation();
     test_left_initialize();
@@ -382,6 +389,7 @@ public:
     test_collect();
     test_list_keys();
     test_search();
+    // test_print_to_console();
   }
 };
 


### PR DESCRIPTION
This change is part of supporting yaml definitions for binary search
trees which are in the `fixtures` directory. To correctly load a
bst fixture, the yaml needs to be processed in order, that is,
reading the key and instantiate a node, then traverse left, then
traverse right. The c++ implementation lack pre_order traversal
at the moment, so the implementation is blocked. Printing to console
is a utility for helping define a pre_order traversal, it will be
the first callback function.

I'm back working full time, and don't have a lot of time to
work through the details of c++ in long sessions.