### PR TITLE
BST-269 remove automatically committing diagram

### DIFF
--- a/.github/workflows/diagram.yml
+++ b/.github/workflows/diagram.yml
@@ -1,17 +1,17 @@
-name: Create diagram
-on:
-  # workflow_dispatch: {}
-  push:
-    # branches:
-    #   - master
+# name: Create diagram
+# on:
+#   # workflow_dispatch: {}
+#   push:
+#     # branches:
+#     #   - master
 
-jobs:
-  get_data:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@master
-      - name: Update diagram
-        uses: githubocto/repo-visualizer@main
-        with:
-          excluded_paths: "ignore,.github"
+# jobs:
+#   get_data:
+#     runs-on: ubuntu-latest
+#     steps:
+#       - name: Checkout code
+#         uses: actions/checkout@master
+#       - name: Update diagram
+#         uses: githubocto/repo-visualizer@main
+#         with:
+#           excluded_paths: "ignore,.github"


### PR DESCRIPTION
The repo visualizer diagram makes an automatic commit and attaches it to
my pull requests, which I find absolutely infuriating. The pull request
which is emitted also fails the title checking action.

I would like to have this capability, but it's too much
trouble for too little payback right now.