### PR TITLE
BST-276 see also BST-266 rubocop gem updates

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -38,6 +38,7 @@ Layout/LineLength:
 Style/MethodDefParentheses:
   EnforcedStyle: require_parentheses
 
+# These are individually ticketed.
 RSpec/MultipleExpectations:
   Enabled: false
 


### PR DESCRIPTION
The parent commit is mis-labeled, it should be
BST-276, not BST-266. This commit provides a pointer
to that error.