### PR TITLE
BST-291 rubocop remediate RSpec/EmptyExampleGroup

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -82,6 +82,5 @@ RSpec/MessageSpies:
 
 RSpec/RepeatedExample:
   Enabled: false
-
-RSpec/EmptyExampleGroup:
-  Enabled: false
+# RSpec/EmptyExampleGroup:
+#   Enabled: false

--- a/ruby/Gemfile.lock
+++ b/ruby/Gemfile.lock
@@ -151,4 +151,4 @@ RUBY VERSION
    ruby 3.1.2p20
 
 BUNDLED WITH
-   2.2.22
+   2.3.21

--- a/ruby/spec/iterative_node_spec.rb
+++ b/ruby/spec/iterative_node_spec.rb
@@ -10,7 +10,7 @@ require 'shared_examples/predecessor'
 
 require_relative '../lib/iterative_node'
 
-RSpec.describe IterativeNode do
+RSpec.describe IterativeNode do # rubocop:disable RSpec/EmptyExampleGroup # false positive
   it_inserts_like 'insertion'
   it_finds_extremes '#maximum'
   it_finds_extremes '#minimum'


### PR DESCRIPTION
This is actually a false positive. All the examples in
the group which is being flagged are shared examples.
Rather than add a superfluous example, it was disabled
at the point.