### PR TITLE
BST-311 Stern-Brocot implementation update

### DIFF
--- a/ruby/lib/stern_brocot.rb
+++ b/ruby/lib/stern_brocot.rb
@@ -1,17 +1,22 @@
 # frozen_string_literal: true
 
+# TODO: spend some serious time checking the impplementation
+# against the algorithn and the theory. Use Knuth et al. for
+# properties of the tree.
 # Stern Brocot trees have the binary search property.
 class SternBrocot
   MAX = (2**((1.size * 8) - 2)) - 1
-  TOL = 0.001
+  TOL = 0.00001
 
-  # rubocop:disable  Metrics/AbcSize
+  # Initialize two values L and H to 0/1 and 1/0, respectively.
+  #  Until q is found, repeat the following steps:
+  #  Let L = a/b and H = c/d; compute the mediant M = (a + c)/(b + d).
+  #  If M is less than q, then q is in the open interval (M,H); replace L by M and continue.
+  #  If M is greater than q, then q is in the open interval (L,M); replace H by M and continue.
+  #  In the remaining case, q = M; terminate the search algorithm.
   # rubocop:disable Metrics/MethodLength
-  def self.rationalize(number)
-    # rubocop:disable Lint/FloatComparison
-    return [0, 1] if number.to_f == 0.0
-
-    # rubocop:enable Lint/FloatComparison
+  def self.rationalize(number) # rubocop:disable  Metrics/AbcSize
+    return [0, 1] if number.to_f == 0.0 # rubocop:disable Lint/FloatComparison
 
     q = number
 
@@ -20,52 +25,44 @@ class SternBrocot
     c = 1
     d = 0
 
-    _l = a / b
-    _h = d.zero? ? MAX : c / d
-    mn = a + b
-    md = c + d
-    m = mn / md.to_f
+    l = a / b
+    h = d.zero? ? MAX : c / d
+    mediant_numerator = a + c
+    mediant_denominator = b + d
+    mediant = mediant_numerator.fdiv(mediant_denominator)
 
     iteration = 1 # ejection handle
 
     loop do
-      return [mn.to_i, md.to_i] if m == q
+      return [mediant_numerator.to_i, mediant_denominator.to_i] if mediant == q
 
-      if m < q
-        a = mn
-        b = md
-        # l = m
+      if mediant < q
+        a = mediant_numerator
+        b = mediant_denominator
+        l = mediant
       else # m > q
-        c = mn
-        d = md
-        # h = m
+        c = mediant_numerator
+        d = mediant_denominator
+        h = mediant
       end
 
-      mn = a + b
-      md = c + d
-      m = mn / md.to_f
+      mediant_numerator = a + c
+      mediant_denominator = b + d
+      mediant = mediant_numerator.fdiv(mediant_denominator)
 
-      # return [mn.to_i, md.to_i] if m == q
-      return [mn.to_i, md.to_i] if (m - q).abs < TOL
+      # return [mediant_numerator.to_i, mediant_denominator.to_i] if m == q
+      return [mediant_numerator.to_i, mediant_denominator.to_i] if (mediant - q).abs < TOL
+
+      # return [l.to_i, h.to_i] if (mediant - q).abs < TOL
 
       iteration += 1
-      # puts md.to_i if md.to_i.modulo(10).zero?
-      break if iteration > 15
+      # puts mediant_denominator.to_i if mediant_denominator.to_i.modulo(10).zero?
+      break if iteration > 20
     end
 
     # also, return if past a certain threshold in precision
     # return [a+b, c+d] if Math.abs(q - number) < 0.0005
-    [mn.to_i, md.to_i]
-
-    # rubocop:disable Layout/LineLength
-    # Initialize two values L and H to 0/1 and 1/0, respectively.
-    #  Until q is found, repeat the following steps:
-    #  Let L = a/b and H = c/d; compute the mediant M = (a + c)/(b + d).
-    #  If M is less than q, then q is in the open interval (M,H); replace L by M and continue.
-    #  If M is greater than q, then q is in the open interval (L,M); replace H by M and continue.
-    #  In the remaining case, q = M; terminate the search algorithm.
-    # rubocop:enable Layout/LineLength
+    [mediant_numerator.to_i, mediant_denominator.to_i]
   end
   # rubocop:enable Metrics/MethodLength
-  # rubocop:enable  Metrics/AbcSize
 end

--- a/ruby/spec/stern_brocot_spec.rb
+++ b/ruby/spec/stern_brocot_spec.rb
@@ -25,6 +25,21 @@ RSpec.describe SternBrocot do
         expect(actual).to eq [2, 1]
       end
 
+      example '13 yields 13/1' do
+        actual = described_class.rationalize 13
+        expect(actual).to eq [13, 1]
+      end
+
+      xexample '99 yields 99/1' do
+        actual = described_class.rationalize 99
+        expect(actual).to eq [99, 1]
+      end
+
+      xexample '731 yields 731/1' do
+        actual = described_class.rationalize 731
+        expect(actual).to eq [731, 1]
+      end
+
       xexample '1246 yields 1246/1' do
         actual = described_class.rationalize 1246
         expect(actual).to eq [1246, 1]
@@ -52,18 +67,25 @@ RSpec.describe SternBrocot do
         expect(actual).to eq [1, 10]
       end
 
-      xexample '0.15 yields 15/100' do
+      example '0.15 yields 15/100' do
         actual = described_class.rationalize 0.15
-        expect(actual).to eq [15, 100]
+        # expect(actual).to eq [15, 100]
+        expect(actual).to eq [3, 20]
       end
 
-      xexample '0.3 yields 3/10' do
+      example '0.3 yields 3/10' do
         actual = described_class.rationalize 0.3
         expect(actual).to eq [3, 10]
       end
 
+      xexample '0.33 yields 33/100' do
+        actual = described_class.rationalize 0.33
+        expect(actual).to eq [33, 100]
+      end
+
       xexample '0.333 yields 333/1000' do
         actual = described_class.rationalize 0.333
+        # binding.pry
         expect(actual).to eq [333, 1000]
       end
     end
@@ -74,10 +96,10 @@ RSpec.describe SternBrocot do
         expect(actual).to eq [11, 10]
       end
 
-      example '3.1'
-      example '5.2'
-      example '9.9'
-      example '123.123'
+      # example '3.1'
+      # example '5.2'
+      # example '9.9'
+      # example '123.123'
     end
 
     #     context 'irrational numbers' do


### PR DESCRIPTION
Doing this right has to deal with all the vagaries of base and representation in binary of number in that base. Using base 10 as default, even numbers such as 0.33 have more nuance than I expected. Going further on the topic would require some really focused study, for which I do not have the energy at the time of writing.